### PR TITLE
repo dataverse: add sha1, restrict tag, dir_label support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tokio",
  "tracing",
@@ -1626,6 +1627,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ native-tls = "0.2.14"
 reqwest = { version = "0.13.2", features = ["__native-tls", "json", "rustls", "stream", "query"] }
 serde = "1.0.228"
 serde_json = "1.0.149"
+sha1 = "0.10.6"
 sha2 = "0.10.9"
 tokio = { version = "1.49.0", features = ["fs", "io-util", "macros", "rt", "rt-multi-thread", "tracing"] }
 tracing = "0.1.44"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tokio",
  "tracing",
@@ -1697,6 +1698,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -33,10 +33,10 @@ use pyo3::{
 };
 use pyo3::{ffi::c_str, types::PyDict};
 use pyo3_async_runtimes::tokio::future_into_py;
-use reqwest::{Client, ClientBuilder};
-use std::{path::PathBuf, sync::Arc};
-use std::time::Duration;
 use reqwest::redirect::Policy;
+use reqwest::{Client, ClientBuilder};
+use std::time::Duration;
+use std::{path::PathBuf, sync::Arc};
 use tokio::sync::Mutex;
 
 pub trait CrawlFileExt {
@@ -160,27 +160,36 @@ impl DOIResolver {
     #[pyo3(signature = (timeout=5))]
     fn new(timeout: u64) -> PyResult<Self> {
         Ok(Self {
-            runtime: tokio::runtime::Runtime::new()
-                .map_err(|err| PyRuntimeError::new_err(format!("failed to create runtime: {err}")))?,
+            runtime: tokio::runtime::Runtime::new().map_err(|err| {
+                PyRuntimeError::new_err(format!("failed to create runtime: {err}"))
+            })?,
             client: Client::builder()
                 .use_native_tls()
                 .timeout(Duration::from_secs(timeout))
                 .redirect(Policy::limited(5)) // limit number of redirects (relevant if follow_redirects is set to true)
                 .build()
-                .map_err(|err| PyRuntimeError::new_err(format!("failed to create client: {err}")))?,
+                .map_err(|err| {
+                    PyRuntimeError::new_err(format!("failed to create client: {err}"))
+                })?,
         })
     }
 
     #[pyo3(signature = (doi, follow_redirects=true))]
     fn resolve(&self, doi: String, follow_redirects: bool) -> PyResult<String> {
         self.runtime
-            .block_on(inner_resolve_doi_to_url(&self.client, &doi, follow_redirects))
+            .block_on(inner_resolve_doi_to_url(
+                &self.client,
+                &doi,
+                follow_redirects,
+            ))
             .map_err(|err| PyRuntimeError::new_err(format!("{err}")))
     }
 
     #[pyo3(signature = (dois, follow_redirects=true))]
     fn resolve_many(&self, dois: Vec<String>, follow_redirects: bool) -> PyResult<Vec<String>> {
-        let futures = dois.iter().map(|doi| inner_resolve_doi_to_url(&self.client, doi, follow_redirects));
+        let futures = dois
+            .iter()
+            .map(|doi| inner_resolve_doi_to_url(&self.client, doi, follow_redirects));
         self.runtime
             .block_on(futures::future::join_all(futures))
             .into_iter()
@@ -300,9 +309,9 @@ impl<'py> IntoPyObject<'py> for PyEntry {
                 py,
                 (
                     PyDirEntry {
-                        path_crawl_rel: PathBuf::from(meta.path.as_str()),
-                        root_url: meta.root_url.as_str().to_string(),
-                        api_url: meta.api_url.as_str().to_string(),
+                        path_crawl_rel: PathBuf::from(meta.path().as_str()),
+                        root_url: meta.root_url().as_str().to_string(),
+                        api_url: meta.api_url().as_str().to_string(),
                     },
                     PyEntryBase,
                 ),
@@ -313,23 +322,21 @@ impl<'py> IntoPyObject<'py> for PyEntry {
                 py,
                 (
                     PyFileEntry {
-                        path_crawl_rel: PathBuf::from(meta.path.as_str()),
-                        download_url: meta.download_url.as_str().to_string(),
-                        size: meta.size,
+                        path_crawl_rel: PathBuf::from(meta.path().as_str()),
+                        download_url: meta.download_url().as_str().to_string(),
+                        size: meta.size(),
                         checksum: meta
-                            .checksum
+                            .checksum()
                             .iter()
                             .map(|cs| match cs {
                                 datahugger::Checksum::Md5(v) => ("md5".to_string(), v.clone()),
                                 datahugger::Checksum::Sha256(v) => {
                                     ("sha256".to_string(), v.clone())
                                 }
+                                datahugger::Checksum::Sha1(v) => ("sha1".to_string(), v.clone()),
                             })
                             .collect::<Vec<_>>(),
-                        mimetype: match meta.mimetype {
-                            Some(mime) => Some(mime.to_string()),
-                            _ => None
-                        }
+                        mimetype: meta.mimetype().map(|mime| mime.to_string()),
                     },
                     PyEntryBase,
                 ),
@@ -356,21 +363,19 @@ impl<'py> IntoPyObject<'py> for PyFileMeta {
             py,
             (
                 PyFileEntry {
-                    path_crawl_rel: PathBuf::from(meta.path.as_str()),
-                    download_url: meta.download_url.as_str().to_string(),
-                    size: meta.size,
+                    path_crawl_rel: PathBuf::from(meta.path().as_str()),
+                    download_url: meta.download_url().as_str().to_string(),
+                    size: meta.size(),
                     checksum: meta
-                        .checksum
+                        .checksum()
                         .iter()
                         .map(|cs| match cs {
                             datahugger::Checksum::Md5(v) => ("md5".to_string(), v.clone()),
                             datahugger::Checksum::Sha256(v) => ("sha256".to_string(), v.clone()),
+                            datahugger::Checksum::Sha1(v) => ("sha1".to_string(), v.clone()),
                         })
                         .collect::<Vec<_>>(),
-                    mimetype: match meta.mimetype {
-                        Some(mime) => Some(mime.to_string()),
-                        _ => None
-                    }
+                    mimetype: meta.mimetype().map(|mime| mime.to_string()),
                 },
                 PyEntryBase,
             ),

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -56,7 +56,7 @@ where
                 .expect("indicatif template error"),
         );
         pb.enable_steady_tick(std::time::Duration::from_millis(100));
-        pb.set_message(format!("listing files of {}", dir.api_url.as_str()));
+        pb.set_message(format!("listing files of {}", dir.api_url().as_str()));
         let entries = dataset_backend.list(&client, dir.clone())
             .await
             .or_raise(||

--- a/src/datasets/arxiv.rs
+++ b/src/datasets/arxiv.rs
@@ -57,6 +57,7 @@ impl DatasetBackend for Arxiv {
             vec![],
             // the mime-type of arxiv.org/pdf/ is surely a valid PDF
             Some(mime::APPLICATION_PDF),
+            true,
         );
 
         Ok(vec![Entry::File(file)])

--- a/src/datasets/dataone.rs
+++ b/src/datasets/dataone.rs
@@ -50,25 +50,25 @@ impl DatasetBackend for Dataone {
     }
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         // TODO: I use xmltree at the moment, which load full xml and then the parsed tree in
@@ -107,7 +107,7 @@ impl DatasetBackend for Dataone {
                             .ok_or_raise(|| RepoError {
                                 message: format!(
                                     "not found download url at {}, through 'physical.distribution.online.url.function.download",
-                                    dir.api_url.as_str()),
+                                    dir.api_url().as_str()),
                             })?;
                         let download_url = Url::from_str(&download_url).map_err(|_| RepoError {
                             message: format!("{download_url} is not a valid download url"),
@@ -133,7 +133,7 @@ impl DatasetBackend for Dataone {
                             .transpose()?;
 
                         let endpoint = Endpoint {
-                            parent_url: dir.api_url.clone(),
+                            parent_url: dir.api_url().clone(),
                             key: Some(
                                 "dataset.physical.distribution.online.url[@function='download']"
                                     .to_string(),
@@ -147,6 +147,7 @@ impl DatasetBackend for Dataone {
                             size,
                             vec![],
                             None,
+                            true,
                         );
                         entries.push(Entry::File(file));
                     }

--- a/src/datasets/dataverse.rs
+++ b/src/datasets/dataverse.rs
@@ -57,29 +57,29 @@ impl DatasetBackend for DataverseDataset {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
 
         let files = resp
@@ -93,12 +93,16 @@ impl DatasetBackend for DataverseDataset {
         let mut entries = Vec::with_capacity(files.len());
         for (idx, filej) in files.iter().enumerate() {
             let endpoint = Endpoint {
-                parent_url: dir.api_url.clone(),
+                parent_url: dir.api_url().clone(),
                 key: Some(format!("data.files.{idx}")),
             };
             let name: String = json_extract(filej, "dataFile.filename").or_raise(|| RepoError {
                 message: "fail to extracting 'dataFile.filename' as String from json".to_string(),
             })?;
+            let restricted: bool = json_extract(filej, "restricted").or_raise(|| RepoError {
+                message: "fail to extracting 'dataFile.filename' as String from json".to_string(),
+            })?;
+            let downloadable = !restricted;
             let id: u64 = json_extract(filej, "dataFile.id").or_raise(|| RepoError {
                 message: "fail to extracting 'dataFile.id' as u64 from json".to_string(),
             })?;
@@ -113,25 +117,59 @@ impl DatasetBackend for DataverseDataset {
             let mime_type = mime::Mime::from_str(&mime_type).or_raise(|| RepoError {
                 message: format!("fail to parse the '{}' to proper mime type", mime_type),
             })?;
-            let download_url = "https://dataverse.harvard.edu/api/access/datafile/";
-            let download_url = Url::from_str(download_url).or_raise(|| RepoError {
-                message: format!("cannot parse '{download_url}' download base url"),
-            })?;
+            let download_url =
+                dir.api_url()
+                    .join("/api/access/datafile/")
+                    .or_raise(|| RepoError {
+                        message: "cannot parse download base url".to_string(),
+                    })?;
             let download_url = download_url.join(&format!("{id}")).or_raise(|| RepoError {
                 message: format!("cannot parse '{download_url}' download url"),
             })?;
-            // XXX: Is dataverse only MD5 support? there is dataFile.checksum.value as well
-            let hash: String = json_extract(filej, "dataFile.md5").or_raise(|| RepoError {
-                message: "fail to extracting 'dataFile.md5' as String from json".to_string(),
-            })?;
-            let checksum = Checksum::Md5(hash);
+            let dst_path = match json_extract::<String>(filej, "directoryLabel") {
+                Ok(dir_label) => dir.join(&format!("{dir_label}/{name}")),
+                Err(_) => dir.join(&name),
+            };
+            let checksum_typ: String =
+                json_extract(filej, "dataFile.checksum.type").or_raise(|| RepoError {
+                    message: "fail to extracting 'dataFile.checksum.type' as String from json"
+                        .to_string(),
+                })?;
+            let checksum = match checksum_typ.as_str() {
+                "MD5" | "md5" => {
+                    let hash: String =
+                        json_extract(filej, "dataFile.checksum.value").or_raise(|| RepoError {
+                            message:
+                                "fail to extracting 'dataFile.checksum.value' as String from json"
+                                    .to_string(),
+                        })?;
+                    Checksum::Md5(hash)
+                }
+                "SHA-1" | "sha-1" => {
+                    let hash: String =
+                        json_extract(filej, "dataFile.checksum.value").or_raise(|| RepoError {
+                            message:
+                                "fail to extracting 'dataFile.checksum.value' as String from json"
+                                    .to_string(),
+                        })?;
+                    Checksum::Sha1(hash)
+                }
+                v => {
+                    exn::bail!(RepoError {
+                        message: format!(
+                            "{v} is not yet support, please open an issue so we can add it"
+                        )
+                    });
+                }
+            };
             let file = FileMeta::new(
-                dir.join(&name),
+                dst_path,
                 endpoint,
                 download_url,
                 Some(size),
                 vec![checksum],
                 Some(mime_type),
+                downloadable,
             );
             entries.push(Entry::File(file));
         }
@@ -187,29 +225,29 @@ impl DatasetBackend for DataverseFile {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
 
         let filej = resp.get("data").ok_or_else(|| RepoError {
@@ -219,6 +257,10 @@ impl DatasetBackend for DataverseFile {
         let name: String = json_extract(filej, "dataFile.filename").or_raise(|| RepoError {
             message: "fail to extracting 'dataFile.filename' as String from json".to_string(),
         })?;
+        let restricted: bool = json_extract(filej, "restricted").or_raise(|| RepoError {
+            message: "fail to extracting 'dataFile.filename' as String from json".to_string(),
+        })?;
+        let downloadable = !restricted;
         let id: u64 = json_extract(filej, "dataFile.id").or_raise(|| RepoError {
             message: "fail to extracting 'dataFile.id' as u64 from json".to_string(),
         })?;
@@ -234,20 +276,21 @@ impl DatasetBackend for DataverseFile {
         let mime_type = mime::Mime::from_str(&mime_type).or_raise(|| RepoError {
             message: format!("fail to parse the '{}' to proper mime type", mime_type),
         })?;
-        let download_url = "https://dataverse.harvard.edu/api/access/datafile/";
-        let download_url = Url::from_str(download_url).or_raise(|| RepoError {
-            message: format!("cannot parse '{download_url}' download base url"),
-        })?;
+        let download_url = dir
+            .api_url()
+            .join("/api/access/datafile/")
+            .or_raise(|| RepoError {
+                message: "cannot parse download base url".to_string(),
+            })?;
         let download_url = download_url.join(&format!("{id}")).or_raise(|| RepoError {
             message: format!("cannot parse '{download_url}' download url"),
         })?;
-        // XXX: Is dataverse only MD5 support? there is dataFile.checksum.value as well
         let hash: String = json_extract(filej, "dataFile.md5").or_raise(|| RepoError {
             message: "fail to extracting 'dataFile.md5' as String from json".to_string(),
         })?;
         let checksum = Checksum::Md5(hash);
         let endpoint = Endpoint {
-            parent_url: dir.api_url.clone(),
+            parent_url: dir.api_url().clone(),
             key: Some("data".to_string()),
         };
         let file = FileMeta::new(
@@ -257,6 +300,7 @@ impl DatasetBackend for DataverseFile {
             Some(size),
             vec![checksum],
             Some(mime_type),
+            downloadable,
         );
         let entries = vec![Entry::File(file)];
 

--- a/src/datasets/dryad.rs
+++ b/src/datasets/dryad.rs
@@ -48,29 +48,29 @@ impl DatasetBackend for DataDryad {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
 
         // get link to the api of latest version of dataset
@@ -107,7 +107,7 @@ impl DatasetBackend for DataDryad {
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
@@ -181,6 +181,7 @@ impl DatasetBackend for DataDryad {
                 Some(size),
                 vec![checksum],
                 Some(mime_type),
+                true,
             );
             entries.push(Entry::File(file));
         }

--- a/src/datasets/github.rs
+++ b/src/datasets/github.rs
@@ -68,7 +68,7 @@ impl DatasetBackend for GitHub {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .map_err(|e| RepoError {
@@ -84,11 +84,11 @@ impl DatasetBackend for GitHub {
         }
 
         let resp = resp.error_for_status().map_err(|e| RepoError {
-            message: format!("HTTP error GET {}: {}", dir.api_url, e),
+            message: format!("HTTP error GET {}: {}", dir.api_url(), e),
         })?;
 
         let json: JsonValue = resp.json().await.map_err(|e| RepoError {
-            message: format!("Failed to parse JSON from {}: {}", dir.api_url, e),
+            message: format!("Failed to parse JSON from {}: {}", dir.api_url(), e),
         })?;
 
         let tree = json
@@ -127,13 +127,14 @@ impl DatasetBackend for GitHub {
                     let file = FileMeta::new(
                         path,
                         Endpoint {
-                            parent_url: dir.api_url.clone(),
+                            parent_url: dir.api_url().clone(),
                             key: Some(format!("tree.{i}")),
                         },
                         download_url,
                         Some(size),
                         vec![],
                         guess.first(),
+                        true,
                     );
                     entries.push(Entry::File(file));
                 }

--- a/src/datasets/hal.rs
+++ b/src/datasets/hal.rs
@@ -65,29 +65,29 @@ impl DatasetBackend for HalScience {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url().clone())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
         let files = resp
             .get("response")
@@ -102,7 +102,7 @@ impl DatasetBackend for HalScience {
         let mut entries = Vec::with_capacity(files.len());
         for (idx, filej) in files.iter().enumerate() {
             let endpoint = Endpoint {
-                parent_url: dir.api_url.clone(),
+                parent_url: dir.api_url(),
                 key: Some(format!("response.docs.0.files_s.{idx}")),
             };
             let JsonValue::String(download_url) = filej else {
@@ -125,6 +125,7 @@ impl DatasetBackend for HalScience {
                 None,
                 vec![],
                 guess.first(),
+                true,
             );
             entries.push(Entry::File(file));
         }

--- a/src/datasets/huggingface.rs
+++ b/src/datasets/huggingface.rs
@@ -63,7 +63,7 @@ impl DatasetBackend for HuggingFace {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url())
             .send()
             .await
             .map_err(|e| RepoError {
@@ -77,11 +77,11 @@ impl DatasetBackend for HuggingFace {
         }
 
         let resp = resp.error_for_status().map_err(|e| RepoError {
-            message: format!("HTTP error GET {}: {e}", dir.api_url),
+            message: format!("HTTP error GET {}: {e}", dir.api_url()),
         })?;
 
         let json: JsonValue = resp.json().await.map_err(|e| RepoError {
-            message: format!("Failed to parse JSON from {}: {e}", dir.api_url),
+            message: format!("Failed to parse JSON from {}: {e}", dir.api_url()),
         })?;
 
         let files = json.as_array().ok_or_else(|| RepoError {
@@ -104,12 +104,12 @@ impl DatasetBackend for HuggingFace {
             match kind.as_str() {
                 "file" => {
                     let size: u64 = json_extract(filej, "size").or_raise(|| RepoError {
-                        message: format!("Missing size from {}", dir.api_url),
+                        message: format!("Missing size from {}", dir.api_url()),
                     })?;
                     let checksum: String = json_extract(filej, "lfs.oid")
                         .or_else(|_| json_extract(filej, "oid"))
                         .or_raise(|| RepoError {
-                            message: format!("Missing 'lfs.oid' from {}", dir.api_url),
+                            message: format!("Missing 'lfs.oid' from {}", dir.api_url()),
                         })?;
                     let checksum = Checksum::Sha256(checksum);
                     let path = dir.join(path);
@@ -120,13 +120,14 @@ impl DatasetBackend for HuggingFace {
                     let file = FileMeta::new(
                         path,
                         Endpoint {
-                            parent_url: dir.api_url.clone(),
+                            parent_url: dir.api_url(),
                             key: Some(format!("filej.{i}")),
                         },
                         download_url,
                         Some(size),
                         vec![checksum],
                         guess.first(),
+                        true,
                     );
 
                     entries.push(Entry::File(file));

--- a/src/datasets/osf.rs
+++ b/src/datasets/osf.rs
@@ -43,29 +43,29 @@ impl DatasetBackend for OSF {
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
         let files = resp
             .get("data")
@@ -77,7 +77,7 @@ impl DatasetBackend for OSF {
         let mut entries = Vec::with_capacity(files.len());
         for (idx, filej) in files.iter().enumerate() {
             let endpoint = Endpoint {
-                parent_url: dir.api_url.clone(),
+                parent_url: dir.api_url(),
                 key: Some(format!("data.{idx}")),
             };
             let name: String = json_extract(filej, "attributes.name").or_raise(|| RepoError {
@@ -115,6 +115,7 @@ impl DatasetBackend for OSF {
                         Some(size),
                         vec![checksum],
                         guess.first(),
+                        true,
                     );
                     entries.push(Entry::File(file));
                 }

--- a/src/datasets/zenodo.rs
+++ b/src/datasets/zenodo.rs
@@ -48,29 +48,29 @@ impl DatasetBackend for Zenodo {
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         // NOTE: for dev, the first entry point url for the `dir.api_url` is the `root_dir` (from `root_url`) of the Dataset
         let resp = client
-            .get(dir.api_url.clone())
+            .get(dir.api_url())
             .send()
             .await
             .or_raise(|| RepoError {
-                message: format!("fail at client sent GET {}", dir.api_url),
+                message: format!("fail at client sent GET {}", dir.api_url()),
             })?;
         let resp = resp.error_for_status().map_err(|err| match err.status() {
             Some(StatusCode::NOT_FOUND) => RepoError {
-                message: format!("resource not found when GET {}", dir.api_url),
+                message: format!("resource not found when GET {}", dir.api_url()),
             },
             Some(status_code) => RepoError {
                 message: format!(
                     "fail GET {}, with state code: {}",
-                    dir.api_url,
+                    dir.api_url(),
                     status_code.as_str()
                 ),
             },
             None => RepoError {
-                message: format!("fail GET {}, network / protocol error", dir.api_url,),
+                message: format!("fail GET {}, network / protocol error", dir.api_url(),),
             },
         })?;
         let resp: JsonValue = resp.json().await.or_raise(|| RepoError {
-            message: format!("fail GET {}, unable to convert to json", dir.api_url,),
+            message: format!("fail GET {}, unable to convert to json", dir.api_url(),),
         })?;
 
         let files = resp
@@ -83,7 +83,7 @@ impl DatasetBackend for Zenodo {
         let mut entries = Vec::with_capacity(files.len());
         for (idx, filej) in files.iter().enumerate() {
             let endpoint = Endpoint {
-                parent_url: dir.api_url.clone(),
+                parent_url: dir.api_url(),
                 key: Some(format!("entries.{idx}")),
             };
             let name: String = json_extract(filej, "key").or_raise(|| RepoError {
@@ -95,7 +95,7 @@ impl DatasetBackend for Zenodo {
             })?;
             let download_url: String =
                 json_extract(filej, "links.content").or_raise(|| RepoError {
-                   message: format!("fail to extracting '_links.stash:download' as String from json, at parsing {}", dir.api_url)
+                   message: format!("fail to extracting '_links.stash:download' as String from json, at parsing {}", dir.api_url())
                 })?;
             let download_url = Url::from_str(&download_url).or_raise(|| RepoError {
                 message: format!("fail to parse download_url from base_url '{download_url}'"),
@@ -136,6 +136,7 @@ impl DatasetBackend for Zenodo {
                 Some(size),
                 vec![checksum],
                 guess.first(),
+                true,
             );
             entries.push(Entry::File(file));
         }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -84,18 +84,30 @@ where
                     .expect("indicatif template error"),
             );
             pb.enable_steady_tick(std::time::Duration::from_millis(100));
-            pb.set_message(format!("Connecting... {}", file_meta.download_url.as_str()));
+            pb.set_message(format!(
+                "Connecting... {}",
+                file_meta.download_url().as_str()
+            ));
+
+            if !file_meta.is_downloadable() {
+                pb.set_message(format!(
+                    "{} is not downloadable",
+                    file_meta.download_url().as_str()
+                ));
+                return Ok(());
+            }
+
             let resp = client
-                .get(file_meta.download_url.clone())
+                .get(file_meta.download_url())
                 .send()
                 .await
                 .or_raise(|| CrawlerError {
-                    message: format!("fail to send http GET to {}", file_meta.download_url),
+                    message: format!("fail to send http GET to {}", file_meta.download_url()),
                     status: ErrorStatus::Temporary,
                 })?
                 .error_for_status()
                 .or_raise(|| CrawlerError {
-                    message: format!("fail to send http GET to {}", file_meta.download_url),
+                    message: format!("fail to send http GET to {}", file_meta.download_url()),
                     // Temporary??
                     status: ErrorStatus::Temporary,
                 })?;
@@ -127,17 +139,18 @@ where
                 })?;
 
             let checksum = file_meta
-                .checksum
+                .checksum()
                 .iter()
                 .find(|c| matches!(c, Checksum::Sha256(_)))
-                .or_else(|| file_meta.checksum.first());
-            let expected_size = file_meta.size;
+                .or_else(|| file_meta.checksum().first());
+            let expected_size = file_meta.size();
             let (mut hasher, expected_checksum) = if let Some(checksum) = checksum {
                 match checksum {
                     Checksum::Sha256(value) => {
                         (Some(Hasher::Sha256(sha2::Sha256::new())), Some(value))
                     }
                     Checksum::Md5(value) => (Some(Hasher::Md5(md5::Md5::new())), Some(value)),
+                    Checksum::Sha1(value) => (Some(Hasher::Sha1(sha1::Sha1::new())), Some(value)),
                 }
             } else {
                 warn!("unable to find expected checksum to verify");
@@ -197,7 +210,9 @@ where
 
                 if checksum != *expected_checksum {
                     exn::bail!(CrawlerError {
-                        message: format!("size wrong, expect {expected_checksum}, got {checksum}"),
+                        message: format!(
+                            "checksum wrong, expect {expected_checksum}, got {checksum}"
+                        ),
                         status: ErrorStatus::Permanent
                     })
                 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -128,6 +128,7 @@ impl CrawlPath {
 pub enum Hasher {
     Md5(md5::Md5),
     Sha256(sha2::Sha256),
+    Sha1(sha1::Sha1),
 }
 
 impl Hasher {
@@ -135,6 +136,7 @@ impl Hasher {
         match self {
             Hasher::Md5(h) => h.update(data),
             Hasher::Sha256(h) => h.update(data),
+            Hasher::Sha1(h) => h.update(data),
         }
     }
 
@@ -143,6 +145,7 @@ impl Hasher {
         match self {
             Hasher::Md5(h) => h.finalize().to_vec(),
             Hasher::Sha256(h) => h.finalize().to_vec(),
+            Hasher::Sha1(h) => h.finalize().to_vec(),
         }
     }
 }
@@ -155,9 +158,9 @@ pub enum Entry {
 
 #[derive(Debug, Clone)]
 pub struct DirMeta {
-    pub path: CrawlPath,
-    pub root_url: Url,
-    pub api_url: Url,
+    path: CrawlPath,
+    root_url: Url,
+    api_url: Url,
 }
 
 impl std::fmt::Display for DirMeta {
@@ -192,8 +195,18 @@ impl DirMeta {
     }
 
     #[must_use]
+    pub fn path(&self) -> CrawlPath {
+        self.path.clone()
+    }
+
+    #[must_use]
     pub fn root_url(&self) -> Url {
         self.root_url.clone()
+    }
+
+    #[must_use]
+    pub fn api_url(&self) -> Url {
+        self.api_url.clone()
     }
 
     #[must_use]
@@ -225,20 +238,56 @@ impl std::fmt::Display for Endpoint {
     }
 }
 
-/// The ``mimetype`` of ``FileMeta`` is get from API response instead of from content resolver
-/// therefore it is not guranted to be correct conform with the content. For example the github
-/// file type is deducted from file extension using `mime-guess` crate.
+// TODO: `FileMetaByScan` will include the full accurate mimetype and size and checksum.
+
+/// Metadata describing a crawled file.
+///
+/// The `mimetype` is taken directly from the API response and is not
+/// validated against the file contents. As a result, it may be incorrect.
+/// For example, some APIs infer MIME types from file extensions rather
+/// than inspecting the actual data.
 #[derive(Debug)]
 pub struct FileMeta {
-    pub path: CrawlPath,
-    pub endpoint: Endpoint,
-    pub download_url: Url,
-    pub size: Option<u64>,
-    pub checksum: Vec<Checksum>,
-    pub mimetype: Option<Mime>,
+    path: CrawlPath,
+    endpoint: Endpoint,
+    download_url: Url,
+    size: Option<u64>,
+    checksum: Vec<Checksum>,
+    mimetype: Option<Mime>,
+    downloadable: bool,
 }
 
-// TODO: `FileMetaByScan` will include the full accurate mimetype and size and checksum.
+impl FileMeta {
+    /// Returns whether the file can be downloaded.
+    pub fn is_downloadable(&self) -> bool {
+        self.downloadable
+    }
+
+    /// Returns the crawl path of the file.
+    pub fn path(&self) -> CrawlPath {
+        self.path.clone()
+    }
+
+    /// Returns the download URL of the file.
+    pub fn download_url(&self) -> Url {
+        self.download_url.clone()
+    }
+
+    /// Returns the checksums associated with the file.
+    pub fn checksum(&self) -> &[Checksum] {
+        &self.checksum
+    }
+
+    /// Returns the file size in bytes if known.
+    pub fn size(&self) -> Option<u64> {
+        self.size
+    }
+
+    /// Returns the mimetype in bytes if known.
+    pub fn mimetype(&self) -> Option<Mime> {
+        self.mimetype.clone()
+    }
+}
 
 impl std::fmt::Display for FileMeta {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -282,6 +331,7 @@ impl FileMeta {
         size: Option<u64>,
         checksum: Vec<Checksum>,
         mimetype: Option<Mime>,
+        downloadable: bool,
     ) -> Self {
         FileMeta {
             path,
@@ -290,6 +340,7 @@ impl FileMeta {
             size,
             checksum,
             mimetype,
+            downloadable,
         }
     }
     #[must_use]
@@ -304,10 +355,11 @@ impl FileMeta {
 
 // XXX: github blob didnt validate, it use sha1 but compute (maybe) with 'blob {}' as prefix of
 // content. I lean to not validate github downloads for simplicity. Only do it when requests come.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Checksum {
     Md5(String),
     Sha256(String),
+    Sha1(String),
 }
 
 impl std::fmt::Display for Checksum {
@@ -315,6 +367,7 @@ impl std::fmt::Display for Checksum {
         match self {
             Checksum::Md5(h) => write!(f, "(md5: {h})"),
             Checksum::Sha256(h) => write!(f, "(sha256: {h})"),
+            Checksum::Sha1(h) => write!(f, "(sha1: {h})"),
         }
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -142,6 +142,11 @@ static DATAVERSE_DOMAINS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
         "datos.pucp.edu.pe",
         "datos.uchile.cl",
         "opendata.pku.edu.cn",
+        "archaeology.datastations.nl",
+        "ssh.datastations.nl",
+        "lifesciences.datastations.nl",
+        "phys-techsciences.datastations.nl",
+        "dataverse.nl",
     ])
 });
 


### PR DESCRIPTION
Some dataverse repository such as https://archaeology.datastations.nl/ has file checksum using sha1. Support added.

The `directoryLabel` is used for marking files in which subfolder folder, use it for download dst.

Some file can be marked as "restricted" so only metadata is exposted but not downloadable. Record this info and used in download op to skip such files.

- [x] python api adapted. (the `is_downloadable` field not added to python API atm)
- [x] all fields of DirMeta and FileMeta become private and instead expose get methods as pub.