### PR TITLE
feat (zenodo): add missing fields

### DIFF
--- a/src/datasets/zenodo.rs
+++ b/src/datasets/zenodo.rs
@@ -137,7 +137,7 @@ impl DatasetBackend for Zenodo {
             let created: String = json_extract(filej, "created").or_raise(|| RepoError {
                 message: "fail to extracting 'created' as String from json".to_string(),
             })?;
-            let updated: String = json_extract(filej, "created").or_raise(|| RepoError {
+            let updated: String = json_extract(filej, "updated").or_raise(|| RepoError {
                 message: "fail to extracting 'updated' as String from json".to_string(),
             })?;
             let file = FileMeta::new(


### PR DESCRIPTION
This PR adds support for recently added `FileMeta` fields for Zenodo backend.