### PR TITLE
feat (cli): add --include glob filter for selective download and inspect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +352,7 @@ dependencies = [
  "exn",
  "futures-core",
  "futures-util",
+ "globset",
  "hex",
  "indicatif",
  "md-5",
@@ -615,6 +626,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.6.0", features = ["derive"] }
 digest = "0.10.7"
 exn = "0.3.0"
 futures-core = "0.3.31"
+globset = "0.4"
 futures-util = "0.3.31"
 hex = "0.4.3"
 indicatif = "0.18.4"

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ o/f/m/a/Lynx rufus.pdf             [------------------------]      0 B/326.02 kB
 o/f/m/a/Ursus arctos.pdf           [------------------------]      0 B/319.05 kB (       0 B/s,  0s)
 ```
 
+To download only specific files, use `--include` with a glob pattern (can be repeated):
+
+```console
+datahugger download https://zenodo.org/records/14640564 --include "*.csv" --to /tmp/only-csvs
+datahugger download https://zenodo.org/records/14640564 --include "README" --include "*.tsv.gz" --to /tmp/selected
+```
+
+Use `inspect` with `--include` to preview which files match before downloading:
+
+```console
+datahugger inspect https://zenodo.org/records/14640564 --include "*.csv"
+```
+
 See more examples at [CLI usage examples](#CLI-Examples).
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -75,14 +75,16 @@ o/f/m/a/Lynx rufus.pdf             [------------------------]      0 B/326.02 kB
 o/f/m/a/Ursus arctos.pdf           [------------------------]      0 B/319.05 kB (       0 B/s,  0s)
 ```
 
-To download only specific files, use `--include` with a glob pattern (can be repeated):
+To download only specific files, use `--include` with a glob pattern (can be repeated).
+To skip unwanted files, use `--exclude` (excludes are applied after includes):
 
 ```console
 datahugger download https://zenodo.org/records/14640564 --include "*.csv" --to /tmp/only-csvs
 datahugger download https://zenodo.org/records/14640564 --include "README" --include "*.tsv.gz" --to /tmp/selected
+datahugger download https://zenodo.org/records/14640564 --exclude "*.log" --to /tmp/no-logs
 ```
 
-Use `inspect` with `--include` to preview which files match before downloading:
+Use `inspect` with `--include` / `--exclude` to preview which files match before downloading:
 
 ```console
 datahugger inspect https://zenodo.org/records/14640564 --include "*.csv"

--- a/examples/multiple-repos.rs
+++ b/examples/multiple-repos.rs
@@ -36,11 +36,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // require:
             // use datahugger::DownloadExt;
             let mp = MultiProgress::new();
-            // let filter = FileFilter::accept_all();
+            // let filter = FileFilter::default();
             // repo.download_with_validation(&client, "./dummy_tests", mp, 0, &filter)
             //     .await
 
-            repo.print_meta(&client, mp, 0, &FileFilter::accept_all())
+            repo.print_meta(&client, mp, 0, &FileFilter::default())
                 .await
         }
     });

--- a/examples/multiple-repos.rs
+++ b/examples/multiple-repos.rs
@@ -1,4 +1,4 @@
-use datahugger::resolve;
+use datahugger::{resolve, FileFilter};
 use futures_util::future::join_all;
 use indicatif::MultiProgress;
 use reqwest::ClientBuilder;
@@ -36,10 +36,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // require:
             // use datahugger::DownloadExt;
             let mp = MultiProgress::new();
-            // repo.download_with_validation(&client, "./dummy_tests", mp, 0)
+            // let filter = FileFilter::accept_all();
+            // repo.download_with_validation(&client, "./dummy_tests", mp, 0, &filter)
             //     .await
 
-            repo.print_meta(&client, mp, 0).await
+            repo.print_meta(&client, mp, 0, &FileFilter::accept_all())
+                .await
         }
     });
 

--- a/examples/multiple-repos.rs
+++ b/examples/multiple-repos.rs
@@ -1,4 +1,4 @@
-use datahugger::{resolve, FileFilter};
+use datahugger::resolve;
 use futures_util::future::join_all;
 use indicatif::MultiProgress;
 use reqwest::ClientBuilder;
@@ -40,8 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // repo.download_with_validation(&client, "./dummy_tests", mp, 0, &filter)
             //     .await
 
-            repo.print_meta(&client, mp, 0, &FileFilter::default())
-                .await
+            repo.print_meta(&client, mp, 0, None).await
         }
     });
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -161,6 +161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +348,7 @@ dependencies = [
  "exn",
  "futures-core",
  "futures-util",
+ "globset",
  "hex",
  "indicatif",
  "md-5",
@@ -610,6 +621,19 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/python/README.md
+++ b/python/README.md
@@ -120,8 +120,8 @@ class Dataset:
     def crawl(self) -> SyncAsyncIterator[FileEntry | DirEntry]: ...
     def crawl_file(self) -> SyncAsyncIterator[FileEntry]: ...
     def download_with_validation(
-        self, dst_dir: pathlib.Path, limit: int = 0
-    ) -> None: ...
+        self, dst_dir: pathlib.Path, limit: int = 0, includes = None, excludes = None,
+    ) -> int: ...
     def id(self) -> str: ...
     def root_url(self) -> str: ...
 ```
@@ -156,8 +156,8 @@ Entries are yielded as either `DirEntry` or `FileEntry`.
 
 ```python
 def download_with_validation(
-    self, dst_dir: pathlib.Path, limit: int = 0
-) -> None
+    self, dst_dir: pathlib.Path, limit: int = 0, includes = None, excludes = None,
+) -> int
 ```
 
 Downloads files in the dataset into the given directory and validates them using the provided checksums.

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -85,8 +85,14 @@ class HalJsonSrcDataset(Dataset):
         """
 
 class Dataset(object):
-    def download_with_validation(self, dst_dir: pathlib.Path, limit: int = 0) -> None:
-        """blocking call, using rust's async runtime"""
+    def download_with_validation(
+        self,
+        dst_dir: pathlib.Path,
+        limit: int = 0,
+        includes: list[str] | None = None,
+        excludes: list[str] | None = None,
+    ) -> int:
+        """blocking call, using rust's async runtime, return number of files it downloads"""
     def crawl_file(self) -> SyncAsyncIterator[FileEntry]:
         """returns a stream that can be either sync or async iterator over `FileEntry`"""
     def crawl(self) -> SyncAsyncIterator[FileEntry | DirEntry]:

--- a/python/devenv.lock
+++ b/python/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1776354588,
-        "narHash": "sha256-NOsJcVAG63emvdlQSpSGQjvHHxcGDfBHd/cgtpduerw=",
+        "lastModified": 1776718099,
+        "narHash": "sha256-JAR6x8Au4xxk6X7ijhlYETQg0F0OS0ihZ5ARiguDclc=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d7aba90c41ee261d215cbe09cf92393cc0ff2606",
+        "rev": "034b677ee035a29a077ecbaadfb2908719272919",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776354229,
-        "narHash": "sha256-M0rboXp08fnK5KE7vJpMWHk9En2DjmuVeiuQAhE8KoM=",
+        "lastModified": 1776758913,
+        "narHash": "sha256-1ujHcHSYEdNlyfVUalf+LLbV3oZ6fcLgLt9Vcx2G6VM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7730a67fc162c8fa9c298b9a53d39a4353484b32",
+        "rev": "9a0c8613542e7b5cb0aa28de3173ffddd7266449",
         "type": "github"
       },
       "original": {
@@ -84,11 +84,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776350315,
-        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
+        "lastModified": 1776741231,
+        "narHash": "sha256-k9G98qzn+7npROUaks8VqCFm7cFtEG8ulQLBBo5lItg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
+        "rev": "02061303f7c4c964f7b4584dabd9e985b4cd442b",
         "type": "github"
       },
       "original": {

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -19,6 +19,7 @@ pub fn main() {
 
 use datahugger::datasets::ZenodoJsonSrcDataset;
 use datahugger::datasets::{DataverseJsonSrcDataset, HalJsonSrcDataset};
+use datahugger::FileFilter;
 use datahugger::{
     crawl,
     crawler::{CrawlerError, ProgressManager},
@@ -225,12 +226,14 @@ impl PyHalJsonSrcDataset {
 
 #[pymethods]
 impl PyDataset {
-    #[pyo3(signature = (dst_dir, limit=0))]
+    #[pyo3(signature = (dst_dir, limit=0, includes=None, excludes=None))]
     fn download_with_validation(
         self_: PyRef<'_, Self>,
         dst_dir: PathBuf,
         limit: usize,
-    ) -> PyResult<()> {
+        includes: Option<Vec<String>>,
+        excludes: Option<Vec<String>>,
+    ) -> PyResult<usize> {
         let user_agent = format!("datahugger-py/{}", env!("CARGO_PKG_VERSION"));
         let client = ClientBuilder::new()
             .user_agent(user_agent)
@@ -240,14 +243,26 @@ impl PyDataset {
 
         // blocking call to download, not ideal, but just to sync with original API.
         let rt = tokio::runtime::Runtime::new().expect("unable to create tokio runtime");
+        let filter: Option<FileFilter> = {
+            let includes = includes.unwrap_or_default();
+            let excludes = excludes.unwrap_or_default();
+
+            if includes.is_empty() && excludes.is_empty() {
+                None
+            } else {
+                Some(
+                    FileFilter::new(&includes, &excludes)
+                        .map_err(|err| PyRuntimeError::new_err(format!("{err}")))?,
+                )
+            }
+        };
         rt.block_on(async move {
             self_
                 .0
                 .clone()
-                .download_with_validation(&client, dst_dir, mp, limit, &datahugger::FileFilter::default())
+                .download_with_validation(&client, dst_dir, mp, limit, filter.as_ref())
                 .await
         })
-        .map(|_| ())
         .map_err(|err| PyRuntimeError::new_err(format!("{err}")))
     }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -244,9 +244,10 @@ impl PyDataset {
             self_
                 .0
                 .clone()
-                .download_with_validation(&client, dst_dir, mp, limit)
+                .download_with_validation(&client, dst_dir, mp, limit, &datahugger::FileFilter::accept_all())
                 .await
         })
+        .map(|_| ())
         .map_err(|err| PyRuntimeError::new_err(format!("{err}")))
     }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -244,7 +244,7 @@ impl PyDataset {
             self_
                 .0
                 .clone()
-                .download_with_validation(&client, dst_dir, mp, limit, &datahugger::FileFilter::accept_all())
+                .download_with_validation(&client, dst_dir, mp, limit, &datahugger::FileFilter::default())
                 .await
         })
         .map(|_| ())

--- a/python/tests/test_default.py
+++ b/python/tests/test_default.py
@@ -61,7 +61,15 @@ def test_download(tmp_path: Path) -> None:
     ds = resolve(
         "https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/KBHLOD"
     )
-    ds.download_with_validation(tmp_path)
+    nf = ds.download_with_validation(
+        tmp_path,
+        includes=None,
+        excludes=["tutorial4.py"],
+    )
+
+    assert "tutorial4.py" not in [i.name for i in tmp_path.iterdir()]
+    assert nf == 6
+
     assert sorted([i.name for i in tmp_path.iterdir()]) == [
         "ECM_matrix.py",
         "Markov_comp.py",
@@ -69,7 +77,6 @@ def test_download(tmp_path: Path) -> None:
         "tutorial1.py",
         "tutorial2.py",
         "tutorial3.py",
-        "tutorial4.py",
     ]
 
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -10,7 +10,10 @@ use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 ///
 /// Matching is always case-sensitive so that remote API paths behave
 /// consistently across platforms.
-fn build_globset<T: AsRef<str>>(patterns: &[T]) -> Result<GlobSet, globset::Error> {
+fn build_globset<T>(patterns: &[T]) -> Result<GlobSet, globset::Error>
+where
+    T: AsRef<str>,
+{
     let mut builder = GlobSetBuilder::new();
     for pattern in patterns {
         let pattern = pattern.as_ref().replace('\\', "/");
@@ -41,25 +44,14 @@ pub struct FileFilter {
     excludes: GlobSet,
 }
 
-impl Default for FileFilter {
-    /// Creates a filter that accepts all files (no include or exclude rules).
-    fn default() -> Self {
-        FileFilter {
-            includes: GlobSetBuilder::new().build().unwrap(),
-            excludes: GlobSetBuilder::new().build().unwrap(),
-        }
-    }
-}
-
 impl FileFilter {
     /// Creates a filter from include and exclude pattern lists.
     ///
     /// # Errors
     /// Returns an error if any pattern is invalid.
-    pub fn new<I, E>(includes: &[I], excludes: &[E]) -> Result<Self, globset::Error>
+    pub fn new<P>(includes: &[P], excludes: &[P]) -> Result<Self, globset::Error>
     where
-        I: AsRef<str>,
-        E: AsRef<str>,
+        P: AsRef<str>,
     {
         Ok(FileFilter {
             includes: build_globset(includes)?,
@@ -89,15 +81,7 @@ impl FileFilter {
 mod tests {
     use super::*;
 
-    // ── include-only ────────────────────────────────────────────
-
-    #[test]
-    fn default_matches_everything() {
-        let f = FileFilter::default();
-        assert!(f.matches("anything.csv"));
-        assert!(f.matches("dir/file.txt"));
-        assert!(f.is_accept_all());
-    }
+    // include
 
     #[test]
     fn single_extension_pattern() {
@@ -220,7 +204,7 @@ mod tests {
         assert!(f.matches("a/b/c/deep.txt"));
     }
 
-    // ── exclude-only ────────────────────────────────────────────
+    // exclude-only
 
     #[test]
     fn exclude_rejects_matching_files() {
@@ -237,7 +221,7 @@ mod tests {
         assert!(!f.matches("raw/data.csv"));
     }
 
-    // ── include + exclude combined ──────────────────────────────
+    // include + exclude combined
 
     #[test]
     fn include_and_exclude_combined() {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,75 +1,87 @@
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 
-/// A compiled set of glob patterns for filtering file entries by relative path.
+/// Build a `GlobSet` from a list of pattern strings.
 ///
-/// When no patterns are provided (via `accept_all()`), all files pass the filter.
-/// When one or more patterns are provided, a file passes if it matches ANY pattern.
+/// Each pattern is normalised so that:
+/// - Backslashes are replaced with forward slashes (Windows compat).
+/// - Bare names without a path separator are prefixed with `**/`
+///   so they match at any depth (like rsync / rclone).
+/// - Bare `**` and patterns already starting with `**/` are left as-is.
+///
+/// Matching is always case-sensitive so that remote API paths behave
+/// consistently across platforms.
+fn build_globset<T: AsRef<str>>(patterns: &[T]) -> Result<GlobSet, globset::Error> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        let pattern = pattern.as_ref().replace('\\', "/");
+
+        let normalized = if pattern == "**" || pattern.starts_with("**/") || pattern.contains('/') {
+            pattern
+        } else {
+            format!("**/{pattern}")
+        };
+
+        let glob = GlobBuilder::new(&normalized)
+            .case_insensitive(false)
+            .build()?;
+        builder.add(glob);
+    }
+    builder.build()
+}
+
+/// A compiled pair of include/exclude glob sets for filtering file entries
+/// by relative path.
+///
+/// - An empty `includes` set matches everything.
+/// - A file passes the filter when it matches the include rules (or there
+///   are none) **and** does not match any exclude rule.
 #[derive(Clone, Debug)]
 pub struct FileFilter {
-    inner: Option<GlobSet>,
+    includes: GlobSet,
+    excludes: GlobSet,
+}
+
+impl Default for FileFilter {
+    /// Creates a filter that accepts all files (no include or exclude rules).
+    fn default() -> Self {
+        FileFilter {
+            includes: GlobSetBuilder::new().build().unwrap(),
+            excludes: GlobSetBuilder::new().build().unwrap(),
+        }
+    }
 }
 
 impl FileFilter {
-    /// Creates a filter that accepts all files (no filtering).
-    #[must_use]
-    pub fn accept_all() -> Self {
-        FileFilter { inner: None }
-    }
-
-    /// Creates a filter from a list of glob pattern strings.
+    /// Creates a filter from include and exclude pattern lists.
     ///
     /// # Errors
     /// Returns an error if any pattern is invalid.
-    pub fn from_patterns(patterns: &[String]) -> Result<Self, globset::Error> {
-        if patterns.is_empty() {
-            return Ok(Self::accept_all());
-        }
-        let mut builder = GlobSetBuilder::new();
-        for pattern in patterns {
-            // Normalize Windows backslashes to forward slashes so patterns like
-            // "subdir\*.csv" match CrawlPaths which always use '/'.
-            let pattern = pattern.replace('\\', "/");
-
-            // Patterns without a path separator match at any depth (like rsync/rclone).
-            // globset only auto-prefixes `**/` for patterns with wildcards, so we
-            // normalize literal filenames (e.g. "file.h5" → "**/file.h5") ourselves.
-            // Bare "**" is left as-is since it already matches everything.
-            let normalized = if pattern == "**"
-                || pattern.starts_with("**/")
-                || pattern.contains('/')
-            {
-                pattern
-            } else {
-                format!("**/{pattern}")
-            };
-
-            // Explicitly enforce case-sensitive matching on all platforms so that
-            // remote API paths (which have fixed casing) behave consistently.
-            let glob = GlobBuilder::new(&normalized)
-                .case_insensitive(false)
-                .build()?;
-            builder.add(glob);
-        }
+    pub fn new<I, E>(includes: &[I], excludes: &[E]) -> Result<Self, globset::Error>
+    where
+        I: AsRef<str>,
+        E: AsRef<str>,
+    {
         Ok(FileFilter {
-            inner: Some(builder.build()?),
+            includes: build_globset(includes)?,
+            excludes: build_globset(excludes)?,
         })
     }
 
-    /// Returns true if the given relative path matches the filter.
+    /// Returns `true` if the given relative path passes the filter.
     ///
-    /// If no patterns are set, always returns true.
+    /// A path passes when it is included (or no include rules are set)
+    /// **and** it is not excluded.
     #[must_use]
     pub fn matches(&self, path: &str) -> bool {
-        match &self.inner {
-            None => true,
-            Some(globset) => globset.is_match(path),
-        }
+        let included = self.includes.is_empty() || self.includes.is_match(path);
+        included && !self.excludes.is_match(path)
     }
 
-    /// Returns true if this filter accepts all files (no patterns set).
+    /// Returns `true` if this filter accepts all files
+    /// (no include and no exclude rules).
     #[must_use]
     pub fn is_accept_all(&self) -> bool {
-        self.inner.is_none()
+        self.includes.is_empty() && self.excludes.is_empty()
     }
 }
 
@@ -77,9 +89,11 @@ impl FileFilter {
 mod tests {
     use super::*;
 
+    // ── include-only ────────────────────────────────────────────
+
     #[test]
-    fn accept_all_matches_everything() {
-        let f = FileFilter::accept_all();
+    fn default_matches_everything() {
+        let f = FileFilter::default();
         assert!(f.matches("anything.csv"));
         assert!(f.matches("dir/file.txt"));
         assert!(f.is_accept_all());
@@ -87,7 +101,7 @@ mod tests {
 
     #[test]
     fn single_extension_pattern() {
-        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.csv"], &[] as &[&str]).unwrap();
         assert!(f.matches("data.csv"));
         assert!(f.matches("dir/data.csv"));
         assert!(!f.matches("data.tsv"));
@@ -95,7 +109,7 @@ mod tests {
 
     #[test]
     fn multiple_patterns_or_semantics() {
-        let f = FileFilter::from_patterns(&["*.csv".to_string(), "*.tsv".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.csv", "*.tsv"], &[] as &[&str]).unwrap();
         assert!(f.matches("a.csv"));
         assert!(f.matches("b.tsv"));
         assert!(!f.matches("c.json"));
@@ -103,7 +117,7 @@ mod tests {
 
     #[test]
     fn exact_filename() {
-        let f = FileFilter::from_patterns(&["specific_file.h5".to_string()]).unwrap();
+        let f = FileFilter::new(&["specific_file.h5"], &[] as &[&str]).unwrap();
         assert!(f.matches("specific_file.h5"));
         assert!(f.matches("dir/specific_file.h5"));
         assert!(!f.matches("other_file.h5"));
@@ -111,28 +125,27 @@ mod tests {
 
     #[test]
     fn subdir_glob() {
-        let f = FileFilter::from_patterns(&["subdir/*".to_string()]).unwrap();
+        let f = FileFilter::new(&["subdir/*"], &[] as &[&str]).unwrap();
         assert!(f.matches("subdir/file.csv"));
         assert!(!f.matches("other/file.csv"));
     }
 
     #[test]
     fn empty_patterns_is_accept_all() {
-        let f = FileFilter::from_patterns(&[]).unwrap();
+        let f = FileFilter::new(&[] as &[&str], &[] as &[&str]).unwrap();
         assert!(f.is_accept_all());
         assert!(f.matches("anything"));
     }
 
     #[test]
     fn invalid_pattern_returns_error() {
-        let result = FileFilter::from_patterns(&["[invalid".to_string()]);
+        let result = FileFilter::new(&["[invalid"], &[] as &[&str]);
         assert!(result.is_err());
     }
 
     #[test]
     fn pattern_with_explicit_double_star_prefix() {
-        // Patterns already starting with **/ should not get double-prefixed.
-        let f = FileFilter::from_patterns(&["**/data.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["**/data.csv"], &[] as &[&str]).unwrap();
         assert!(f.matches("data.csv"));
         assert!(f.matches("sub/data.csv"));
         assert!(f.matches("a/b/c/data.csv"));
@@ -141,8 +154,7 @@ mod tests {
 
     #[test]
     fn pattern_with_path_separator_skips_normalization() {
-        // Patterns containing '/' are used as-is (no **/ prefix).
-        let f = FileFilter::from_patterns(&["data/results/*.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["data/results/*.csv"], &[] as &[&str]).unwrap();
         assert!(f.matches("data/results/output.csv"));
         assert!(!f.matches("other/results/output.csv"));
         assert!(!f.matches("data/results/output.tsv"));
@@ -150,22 +162,21 @@ mod tests {
 
     #[test]
     fn deeply_nested_file_matches_extension_glob() {
-        let f = FileFilter::from_patterns(&["*.h5".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.h5"], &[] as &[&str]).unwrap();
         assert!(f.matches("a/b/c/d/e/model.h5"));
         assert!(!f.matches("a/b/c/d/e/model.csv"));
     }
 
     #[test]
     fn filter_is_not_accept_all_when_patterns_set() {
-        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.csv"], &[] as &[&str]).unwrap();
         assert!(!f.is_accept_all());
     }
 
     #[test]
     fn clone_produces_independent_filter() {
-        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.csv"], &[] as &[&str]).unwrap();
         let f2 = f.clone();
-        // Both should work independently.
         assert!(f.matches("data.csv"));
         assert!(f2.matches("data.csv"));
         assert!(!f2.matches("data.tsv"));
@@ -173,31 +184,20 @@ mod tests {
 
     #[test]
     fn case_sensitive_matching() {
-        // We explicitly enforce case-sensitive matching on all platforms
-        // so remote API paths behave consistently.
-        let f = FileFilter::from_patterns(&["*.CSV".to_string()]).unwrap();
+        let f = FileFilter::new(&["*.CSV"], &[] as &[&str]).unwrap();
         assert!(f.matches("data.CSV"));
         assert!(!f.matches("data.csv"));
     }
 
     #[test]
     fn pattern_matching_full_path_with_leading_slash() {
-        // Relative paths should not start with '/' in practice,
-        // but verify the filter handles it without panic.
-        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
-        // globset may or may not match leading-slash paths — just ensure no panic.
+        let f = FileFilter::new(&["*.csv"], &[] as &[&str]).unwrap();
         let _ = f.matches("/root/data.csv");
     }
 
     #[test]
     fn mixed_pattern_types() {
-        // Combine extension glob, exact filename, and path glob.
-        let f = FileFilter::from_patterns(&[
-            "*.csv".to_string(),
-            "README.md".to_string(),
-            "docs/*.pdf".to_string(),
-        ])
-        .unwrap();
+        let f = FileFilter::new(&["*.csv", "README.md", "docs/*.pdf"], &[] as &[&str]).unwrap();
         assert!(f.matches("data.csv"));
         assert!(f.matches("sub/README.md"));
         assert!(f.matches("docs/paper.pdf"));
@@ -207,17 +207,67 @@ mod tests {
 
     #[test]
     fn windows_backslash_normalized_to_forward_slash() {
-        let f = FileFilter::from_patterns(&["subdir\\*.csv".to_string()]).unwrap();
+        let f = FileFilter::new(&["subdir\\*.csv"], &[] as &[&str]).unwrap();
         assert!(f.matches("subdir/data.csv"));
         assert!(!f.matches("other/data.csv"));
     }
 
     #[test]
     fn bare_double_star_matches_everything() {
-        // "**" should match root-level and nested files without being mangled to "**/**".
-        let f = FileFilter::from_patterns(&["**".to_string()]).unwrap();
+        let f = FileFilter::new(&["**"], &[] as &[&str]).unwrap();
         assert!(f.matches("README.md"));
         assert!(f.matches("sub/data.csv"));
         assert!(f.matches("a/b/c/deep.txt"));
+    }
+
+    // ── exclude-only ────────────────────────────────────────────
+
+    #[test]
+    fn exclude_rejects_matching_files() {
+        let f = FileFilter::new(&[] as &[&str], &["*.log"]).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(!f.matches("debug.log"));
+        assert!(!f.matches("sub/error.log"));
+    }
+
+    #[test]
+    fn exclude_subdir() {
+        let f = FileFilter::new(&[] as &[&str], &["raw/*"]).unwrap();
+        assert!(f.matches("clean/data.csv"));
+        assert!(!f.matches("raw/data.csv"));
+    }
+
+    // ── include + exclude combined ──────────────────────────────
+
+    #[test]
+    fn include_and_exclude_combined() {
+        let f = FileFilter::new(&["*.csv"], &["test_*"]).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(!f.matches("test_data.csv"));
+        assert!(!f.matches("data.json"));
+    }
+
+    #[test]
+    fn exclude_overrides_include() {
+        let f = FileFilter::new(&["*.csv", "*.tsv"], &["*.tsv"]).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(!f.matches("data.tsv"));
+    }
+
+    #[test]
+    fn is_not_accept_all_with_excludes_only() {
+        let f = FileFilter::new(&[] as &[&str], &["*.log"]).unwrap();
+        assert!(!f.is_accept_all());
+    }
+
+    // ── accepts String and &str ─────────────────────────────────
+
+    #[test]
+    fn accepts_owned_strings() {
+        let inc = vec!["*.csv".to_string()];
+        let exc = vec!["raw/*".to_string()];
+        let f = FileFilter::new(&inc, &exc).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(!f.matches("raw/data.csv"));
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,223 @@
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+
+/// A compiled set of glob patterns for filtering file entries by relative path.
+///
+/// When no patterns are provided (via `accept_all()`), all files pass the filter.
+/// When one or more patterns are provided, a file passes if it matches ANY pattern.
+#[derive(Clone, Debug)]
+pub struct FileFilter {
+    inner: Option<GlobSet>,
+}
+
+impl FileFilter {
+    /// Creates a filter that accepts all files (no filtering).
+    #[must_use]
+    pub fn accept_all() -> Self {
+        FileFilter { inner: None }
+    }
+
+    /// Creates a filter from a list of glob pattern strings.
+    ///
+    /// # Errors
+    /// Returns an error if any pattern is invalid.
+    pub fn from_patterns(patterns: &[String]) -> Result<Self, globset::Error> {
+        if patterns.is_empty() {
+            return Ok(Self::accept_all());
+        }
+        let mut builder = GlobSetBuilder::new();
+        for pattern in patterns {
+            // Normalize Windows backslashes to forward slashes so patterns like
+            // "subdir\*.csv" match CrawlPaths which always use '/'.
+            let pattern = pattern.replace('\\', "/");
+
+            // Patterns without a path separator match at any depth (like rsync/rclone).
+            // globset only auto-prefixes `**/` for patterns with wildcards, so we
+            // normalize literal filenames (e.g. "file.h5" → "**/file.h5") ourselves.
+            // Bare "**" is left as-is since it already matches everything.
+            let normalized = if pattern == "**"
+                || pattern.starts_with("**/")
+                || pattern.contains('/')
+            {
+                pattern
+            } else {
+                format!("**/{pattern}")
+            };
+
+            // Explicitly enforce case-sensitive matching on all platforms so that
+            // remote API paths (which have fixed casing) behave consistently.
+            let glob = GlobBuilder::new(&normalized)
+                .case_insensitive(false)
+                .build()?;
+            builder.add(glob);
+        }
+        Ok(FileFilter {
+            inner: Some(builder.build()?),
+        })
+    }
+
+    /// Returns true if the given relative path matches the filter.
+    ///
+    /// If no patterns are set, always returns true.
+    #[must_use]
+    pub fn matches(&self, path: &str) -> bool {
+        match &self.inner {
+            None => true,
+            Some(globset) => globset.is_match(path),
+        }
+    }
+
+    /// Returns true if this filter accepts all files (no patterns set).
+    #[must_use]
+    pub fn is_accept_all(&self) -> bool {
+        self.inner.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accept_all_matches_everything() {
+        let f = FileFilter::accept_all();
+        assert!(f.matches("anything.csv"));
+        assert!(f.matches("dir/file.txt"));
+        assert!(f.is_accept_all());
+    }
+
+    #[test]
+    fn single_extension_pattern() {
+        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(f.matches("dir/data.csv"));
+        assert!(!f.matches("data.tsv"));
+    }
+
+    #[test]
+    fn multiple_patterns_or_semantics() {
+        let f = FileFilter::from_patterns(&["*.csv".to_string(), "*.tsv".to_string()]).unwrap();
+        assert!(f.matches("a.csv"));
+        assert!(f.matches("b.tsv"));
+        assert!(!f.matches("c.json"));
+    }
+
+    #[test]
+    fn exact_filename() {
+        let f = FileFilter::from_patterns(&["specific_file.h5".to_string()]).unwrap();
+        assert!(f.matches("specific_file.h5"));
+        assert!(f.matches("dir/specific_file.h5"));
+        assert!(!f.matches("other_file.h5"));
+    }
+
+    #[test]
+    fn subdir_glob() {
+        let f = FileFilter::from_patterns(&["subdir/*".to_string()]).unwrap();
+        assert!(f.matches("subdir/file.csv"));
+        assert!(!f.matches("other/file.csv"));
+    }
+
+    #[test]
+    fn empty_patterns_is_accept_all() {
+        let f = FileFilter::from_patterns(&[]).unwrap();
+        assert!(f.is_accept_all());
+        assert!(f.matches("anything"));
+    }
+
+    #[test]
+    fn invalid_pattern_returns_error() {
+        let result = FileFilter::from_patterns(&["[invalid".to_string()]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pattern_with_explicit_double_star_prefix() {
+        // Patterns already starting with **/ should not get double-prefixed.
+        let f = FileFilter::from_patterns(&["**/data.csv".to_string()]).unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(f.matches("sub/data.csv"));
+        assert!(f.matches("a/b/c/data.csv"));
+        assert!(!f.matches("data.tsv"));
+    }
+
+    #[test]
+    fn pattern_with_path_separator_skips_normalization() {
+        // Patterns containing '/' are used as-is (no **/ prefix).
+        let f = FileFilter::from_patterns(&["data/results/*.csv".to_string()]).unwrap();
+        assert!(f.matches("data/results/output.csv"));
+        assert!(!f.matches("other/results/output.csv"));
+        assert!(!f.matches("data/results/output.tsv"));
+    }
+
+    #[test]
+    fn deeply_nested_file_matches_extension_glob() {
+        let f = FileFilter::from_patterns(&["*.h5".to_string()]).unwrap();
+        assert!(f.matches("a/b/c/d/e/model.h5"));
+        assert!(!f.matches("a/b/c/d/e/model.csv"));
+    }
+
+    #[test]
+    fn filter_is_not_accept_all_when_patterns_set() {
+        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        assert!(!f.is_accept_all());
+    }
+
+    #[test]
+    fn clone_produces_independent_filter() {
+        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        let f2 = f.clone();
+        // Both should work independently.
+        assert!(f.matches("data.csv"));
+        assert!(f2.matches("data.csv"));
+        assert!(!f2.matches("data.tsv"));
+    }
+
+    #[test]
+    fn case_sensitive_matching() {
+        // We explicitly enforce case-sensitive matching on all platforms
+        // so remote API paths behave consistently.
+        let f = FileFilter::from_patterns(&["*.CSV".to_string()]).unwrap();
+        assert!(f.matches("data.CSV"));
+        assert!(!f.matches("data.csv"));
+    }
+
+    #[test]
+    fn pattern_matching_full_path_with_leading_slash() {
+        // Relative paths should not start with '/' in practice,
+        // but verify the filter handles it without panic.
+        let f = FileFilter::from_patterns(&["*.csv".to_string()]).unwrap();
+        // globset may or may not match leading-slash paths — just ensure no panic.
+        let _ = f.matches("/root/data.csv");
+    }
+
+    #[test]
+    fn mixed_pattern_types() {
+        // Combine extension glob, exact filename, and path glob.
+        let f = FileFilter::from_patterns(&[
+            "*.csv".to_string(),
+            "README.md".to_string(),
+            "docs/*.pdf".to_string(),
+        ])
+        .unwrap();
+        assert!(f.matches("data.csv"));
+        assert!(f.matches("sub/README.md"));
+        assert!(f.matches("docs/paper.pdf"));
+        assert!(!f.matches("data.json"));
+        assert!(!f.matches("src/main.rs"));
+    }
+
+    #[test]
+    fn windows_backslash_normalized_to_forward_slash() {
+        let f = FileFilter::from_patterns(&["subdir\\*.csv".to_string()]).unwrap();
+        assert!(f.matches("subdir/data.csv"));
+        assert!(!f.matches("other/data.csv"));
+    }
+
+    #[test]
+    fn bare_double_star_matches_everything() {
+        // "**" should match root-level and nested files without being mangled to "**/**".
+        let f = FileFilter::from_patterns(&["**".to_string()]).unwrap();
+        assert!(f.matches("README.md"));
+        assert!(f.matches("sub/data.csv"));
+        assert!(f.matches("a/b/c/deep.txt"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub use crate::repo::Entry;
 pub use crate::repo::FileMeta;
 pub use crate::repo::Hasher;
 
+mod filter;
+pub use crate::filter::FileFilter;
+
 mod helper;
 
 mod resolver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::PathBuf};
 
 use clap::{Args, Parser, Subcommand};
-use datahugger::{resolve, DownloadExt};
+use datahugger::{resolve, DownloadExt, FileFilter};
 use indicatif::MultiProgress;
 use reqwest::{
     header::{HeaderMap, HeaderValue, AUTHORIZATION, USER_AGENT},
@@ -38,6 +38,11 @@ struct InspectArgs {
     /// For a single dataset record, leaving this unlimited is usually fine.
     #[arg(short, long, default_value_t = 0)]
     limit: usize,
+
+    /// Only show files matching this glob pattern.
+    /// Can be specified multiple times. If omitted, all files are shown.
+    #[arg(long)]
+    include: Vec<String>,
 }
 
 #[derive(Args)]
@@ -58,6 +63,11 @@ struct DownloadArgs {
     /// Defaults to the current directory (`"./"`).
     #[arg(short, long, value_name = "DIR")]
     to: Option<PathBuf>,
+
+    /// Only download files matching this glob pattern.
+    /// Can be specified multiple times. If omitted, all files are downloaded.
+    #[arg(long)]
+    include: Vec<String>,
 }
 
 #[tokio::main]
@@ -79,6 +89,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Download(args) => {
             let url = &args.url;
+            let filter = FileFilter::from_patterns(&args.include).unwrap_or_else(|err| {
+                eprintln!("invalid --include pattern: {err}");
+                std::process::exit(1);
+            });
             let user_agent = format!("datahugger-cli/{}", env!("CARGO_PKG_VERSION"));
             let mut headers = HeaderMap::new();
             if let Ok(token) = std::env::var("GITHUB_TOKEN") {
@@ -110,16 +124,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mp = MultiProgress::new();
             let dst = args.to.unwrap_or_else(|| PathBuf::from("."));
             fs::create_dir_all(&dst)?;
-            let _ = repo
-                .download_with_validation(&client, dst, mp, args.limit)
+            let count = repo
+                .download_with_validation(&client, dst, mp, args.limit, &filter)
                 .await
                 .map_err(|err| {
                     eprintln!("download failed: {err:?}");
                     std::process::exit(1);
-                });
+                })
+                .unwrap_or(0);
+            if !filter.is_accept_all() && count == 0 {
+                eprintln!("warning: no files matched the --include pattern(s)");
+            }
         }
         Commands::Inspect(args) => {
             let url = &args.url;
+            let filter = FileFilter::from_patterns(&args.include).unwrap_or_else(|err| {
+                eprintln!("invalid --include pattern: {err}");
+                std::process::exit(1);
+            });
             let user_agent = format!("datahugger-cli/{}", env!("CARGO_PKG_VERSION"));
             let mut headers = HeaderMap::new();
             if let Ok(token) = std::env::var("GITHUB_TOKEN") {
@@ -149,13 +171,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             let mp = MultiProgress::new();
-            let _ = repo
-                .print_meta(&client, mp, args.limit)
+            let count = repo
+                .print_meta(&client, mp, args.limit, &filter)
                 .await
                 .map_err(|err| {
                     eprintln!("inspect failed: {err:?}");
                     std::process::exit(1);
-                });
+                })
+                .unwrap_or(0);
+            if !filter.is_accept_all() && count == 0 {
+                eprintln!("warning: no files matched the --include pattern(s)");
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,11 @@ struct InspectArgs {
     /// Can be specified multiple times. If omitted, all files are shown.
     #[arg(long)]
     include: Vec<String>,
+
+    /// Exclude files matching this glob pattern.
+    /// Can be specified multiple times. Excludes are applied after includes.
+    #[arg(long)]
+    exclude: Vec<String>,
 }
 
 #[derive(Args)]
@@ -68,6 +73,11 @@ struct DownloadArgs {
     /// Can be specified multiple times. If omitted, all files are downloaded.
     #[arg(long)]
     include: Vec<String>,
+
+    /// Exclude files matching this glob pattern.
+    /// Can be specified multiple times. Excludes are applied after includes.
+    #[arg(long)]
+    exclude: Vec<String>,
 }
 
 #[tokio::main]
@@ -89,8 +99,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Download(args) => {
             let url = &args.url;
-            let filter = FileFilter::from_patterns(&args.include).unwrap_or_else(|err| {
-                eprintln!("invalid --include pattern: {err}");
+            let filter = FileFilter::new(&args.include, &args.exclude).unwrap_or_else(|err| {
+                eprintln!("invalid --include/--exclude pattern: {err}");
                 std::process::exit(1);
             });
             let user_agent = format!("datahugger-cli/{}", env!("CARGO_PKG_VERSION"));
@@ -133,13 +143,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .unwrap_or(0);
             if !filter.is_accept_all() && count == 0 {
-                eprintln!("warning: no files matched the --include pattern(s)");
+                eprintln!("warning: no files matched the --include/--exclude pattern(s)");
             }
         }
         Commands::Inspect(args) => {
             let url = &args.url;
-            let filter = FileFilter::from_patterns(&args.include).unwrap_or_else(|err| {
-                eprintln!("invalid --include pattern: {err}");
+            let filter = FileFilter::new(&args.include, &args.exclude).unwrap_or_else(|err| {
+                eprintln!("invalid --include/--exclude pattern: {err}");
                 std::process::exit(1);
             });
             let user_agent = format!("datahugger-cli/{}", env!("CARGO_PKG_VERSION"));
@@ -180,7 +190,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 })
                 .unwrap_or(0);
             if !filter.is_accept_all() && count == 0 {
-                eprintln!("warning: no files matched the --include pattern(s)");
+                eprintln!("warning: no files matched the --include/--exclude pattern(s)");
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,10 +99,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Commands::Download(args) => {
             let url = &args.url;
-            let filter = FileFilter::new(&args.include, &args.exclude).unwrap_or_else(|err| {
-                eprintln!("invalid --include/--exclude pattern: {err}");
-                std::process::exit(1);
-            });
             let user_agent = format!("datahugger-cli/{}", env!("CARGO_PKG_VERSION"));
             let mut headers = HeaderMap::new();
             if let Ok(token) = std::env::var("GITHUB_TOKEN") {
@@ -134,8 +130,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mp = MultiProgress::new();
             let dst = args.to.unwrap_or_else(|| PathBuf::from("."));
             fs::create_dir_all(&dst)?;
+
+            let filter = FileFilter::new(&args.include, &args.exclude).unwrap_or_else(|err| {
+                eprintln!("invalid --include/--exclude pattern: {err}");
+                std::process::exit(1);
+            });
             let count = repo
-                .download_with_validation(&client, dst, mp, args.limit, &filter)
+                .download_with_validation(&client, dst, mp, args.limit, Some(&filter))
                 .await
                 .map_err(|err| {
                     eprintln!("download failed: {err:?}");
@@ -182,7 +183,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let mp = MultiProgress::new();
             let count = repo
-                .print_meta(&client, mp, args.limit, &filter)
+                .print_meta(&client, mp, args.limit, Some(&filter))
                 .await
                 .map_err(|err| {
                     eprintln!("inspect failed: {err:?}");

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -42,7 +42,7 @@ impl Dataset {
         crawl(client.clone(), Arc::clone(&self.backend), root_dir, mp)
             .try_filter(move |entry| {
                 let pass = match entry {
-                    Entry::Dir(_) => filter.is_accept_all(),
+                    Entry::Dir(_) => true,
                     Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
                 };
                 futures_util::future::ready(pass)
@@ -346,7 +346,7 @@ impl DownloadExt for Dataset {
         )
         .try_filter(move |entry| {
             let pass = match entry {
-                Entry::Dir(_) => filter.is_accept_all(),
+                Entry::Dir(_) => true,
                 Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
             };
             futures_util::future::ready(pass)

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -33,17 +33,19 @@ impl Dataset {
         client: &Client,
         mp: MultiProgress,
         limit: usize,
-        filter: &FileFilter,
+        filter: Option<&FileFilter>,
     ) -> Result<usize, Exn<CrawlerError>> {
         let root_dir = self.root_dir();
-        let filter = filter.clone();
         let file_count = Arc::new(AtomicUsize::new(0));
         let counter = Arc::clone(&file_count);
         crawl(client.clone(), Arc::clone(&self.backend), root_dir, mp)
             .try_filter(move |entry| {
                 let pass = match entry {
                     Entry::Dir(_) => true,
-                    Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
+                    Entry::File(file_meta) => match filter {
+                        Some(filter) => filter.matches(file_meta.relative().as_str()),
+                        None => true,
+                    },
                 };
                 futures_util::future::ready(pass)
             })
@@ -276,7 +278,7 @@ pub trait DownloadExt {
         dst_dir: P,
         mp: impl ProgressManager,
         limit: usize,
-        filter: &FileFilter,
+        filter: Option<&FileFilter>,
     ) -> Result<usize, Exn<CrawlerError>>
     where
         P: AsRef<Path> + Sync + Send;
@@ -322,7 +324,7 @@ impl DownloadExt for Dataset {
         dst_dir: P,
         mp: impl ProgressManager,
         limit: usize,
-        filter: &FileFilter,
+        filter: Option<&FileFilter>,
     ) -> Result<usize, Exn<CrawlerError>>
     where
         P: AsRef<Path> + Sync + Send,
@@ -335,7 +337,6 @@ impl DownloadExt for Dataset {
             message: format!("cannot create dir at '{}'", path.display()),
             status: ErrorStatus::Permanent,
         })?;
-        let filter = filter.clone();
         let file_count = Arc::new(AtomicUsize::new(0));
         let counter = Arc::clone(&file_count);
         crawl(
@@ -347,7 +348,10 @@ impl DownloadExt for Dataset {
         .try_filter(move |entry| {
             let pass = match entry {
                 Entry::Dir(_) => true,
-                Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
+                Entry::File(file_meta) => match &filter {
+                    Some(filter) => filter.matches(file_meta.relative().as_str()),
+                    None => true,
+                },
             };
             futures_util::future::ready(pass)
         })

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3,6 +3,7 @@ use exn::{Exn, OptionExt, ResultExt};
 use futures_core::stream::BoxStream;
 use futures_util::{StreamExt, TryStreamExt};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use reqwest::Client;
@@ -11,6 +12,7 @@ use crate::{
     crawl,
     crawler::{CrawlerError, ProgressManager},
     error::ErrorStatus,
+    filter::FileFilter,
     Dataset, Entry,
 };
 
@@ -31,26 +33,41 @@ impl Dataset {
         client: &Client,
         mp: MultiProgress,
         limit: usize,
-    ) -> Result<(), Exn<CrawlerError>> {
+        filter: &FileFilter,
+    ) -> Result<usize, Exn<CrawlerError>> {
         let root_dir = self.root_dir();
+        let filter = filter.clone();
+        let file_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&file_count);
         crawl(client.clone(), Arc::clone(&self.backend), root_dir, mp)
-            .try_for_each_concurrent(limit, |entry| async move {
-                match entry {
-                    Entry::Dir(dir_meta) => {
-                        println!("{dir_meta}");
+            .try_filter(move |entry| {
+                let pass = match entry {
+                    Entry::Dir(_) => filter.is_accept_all(),
+                    Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
+                };
+                futures_util::future::ready(pass)
+            })
+            .try_for_each_concurrent(limit, |entry| {
+                let counter = Arc::clone(&counter);
+                async move {
+                    match entry {
+                        Entry::Dir(dir_meta) => {
+                            println!("{dir_meta}");
+                        }
+                        Entry::File(file_meta) => {
+                            counter.fetch_add(1, Ordering::Relaxed);
+                            println!("{file_meta}");
+                        }
                     }
-                    Entry::File(file_meta) => {
-                        println!("{file_meta}");
-                    }
+                    Ok(())
                 }
-                Ok(())
             })
             .await
             .or_raise(|| CrawlerError {
                 message: "crawl, download and validation failed".to_string(),
                 status: ErrorStatus::Permanent,
             })?;
-        Ok(())
+        Ok(file_count.load(Ordering::Relaxed))
     }
 }
 
@@ -259,7 +276,8 @@ pub trait DownloadExt {
         dst_dir: P,
         mp: impl ProgressManager,
         limit: usize,
-    ) -> Result<(), Exn<CrawlerError>>
+        filter: &FileFilter,
+    ) -> Result<usize, Exn<CrawlerError>>
     where
         P: AsRef<Path> + Sync + Send;
 }
@@ -304,7 +322,8 @@ impl DownloadExt for Dataset {
         dst_dir: P,
         mp: impl ProgressManager,
         limit: usize,
-    ) -> Result<(), Exn<CrawlerError>>
+        filter: &FileFilter,
+    ) -> Result<usize, Exn<CrawlerError>>
     where
         P: AsRef<Path> + Sync + Send,
     {
@@ -316,18 +335,32 @@ impl DownloadExt for Dataset {
             message: format!("cannot create dir at '{}'", path.display()),
             status: ErrorStatus::Permanent,
         })?;
+        let filter = filter.clone();
+        let file_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&file_count);
         crawl(
             client.clone(),
             Arc::clone(&self.backend),
             root_dir,
             mp.clone(),
         )
+        .try_filter(move |entry| {
+            let pass = match entry {
+                Entry::Dir(_) => filter.is_accept_all(),
+                Entry::File(file_meta) => filter.matches(file_meta.relative().as_str()),
+            };
+            futures_util::future::ready(pass)
+        })
         // NOTE: limit set to 0 as default for cli download,
         // should set to 20 for polite crawling for every dataset, it limit the stream consumer rate.
         .try_for_each_concurrent(limit, |entry| {
             let dst_dir = dst_dir.as_ref().to_path_buf();
             let mp = mp.clone();
+            let counter = Arc::clone(&counter);
             async move {
+                if matches!(&entry, Entry::File(_)) {
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
                 download_crawled_file_with_validation(client, entry, &dst_dir, mp).await?;
                 Ok(())
             }
@@ -337,7 +370,7 @@ impl DownloadExt for Dataset {
             message: "crawl, download and validation failed".to_string(),
             status: ErrorStatus::Permanent,
         })?;
-        Ok(())
+        Ok(file_count.load(Ordering::Relaxed))
     }
 }
 


### PR DESCRIPTION
I needed this for my project [biodiversity-data-tools](https://github.com/Guthman/biodiversity-data-tools) where downloading entire multi-GB Zenodo records is wasteful when only specific files are needed (e.g. https://zenodo.org/records/14640564). So I decided to implement it. I can tackle the Python bindings once this is merged, should be trivial.

## Summary

- Add `--include` glob flag (repeatable) to `download` and `inspect` commands for selective file filtering
- Uses rclone-style semantics: `--include` alone means "only these files" (no need for a separate `--exclude '*'` like rsync)
- Patterns without `/` match at any depth (e.g. `--include "*.csv"` matches `subdir/file.csv`)
- Multiple patterns use OR semantics
- Returns matched file count and warns when no files matched the filter
- New `FileFilter` type in the public API (wraps `globset::GlobSet`)
- Bumps version to 0.6.0 (breaking: `DownloadExt` trait signature changed)
- Python bindings updated minimally to compile (passes `FileFilter::accept_all()`); full Python-side filtering can follow in a separate PR

## Usage

```bash
# Download only CSVs
datahugger download https://zenodo.org/records/14640564 --include "*.csv" --to /tmp/csvs

# Preview what matches before downloading
datahugger inspect https://zenodo.org/records/14640564 --include "*.csv"

# Multiple patterns
datahugger download https://zenodo.org/records/14640564 --include "README" --include "*.tsv.gz" --to /tmp/selected

# Exact filename
datahugger download https://zenodo.org/records/14640564 --include "datasets.csv.gz" --to /tmp/one-file
```

## Test plan

- [x] 22 unit tests pass (`cargo test`) — 15 new filter tests covering: accept_all, single/multiple patterns, exact filenames, subdir globs, path separator handling, `**/` prefix normalization, clone independence, mixed pattern types
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Manually tested `--include` with `inspect` against: Zenodo, Dataverse, arXiv, HAL, GitHub, OSF
- [x] Backward compatible: no `--include` flag = all files (existing behavior)