### PR TITLE
feat (dabar): add local analyzer for DABAR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,9 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
+ "quick-xml",
  "reqwest",
+ "roxmltree",
  "serde",
  "serde_json",
  "sha1",
@@ -1225,6 +1227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1423,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 url = "2.5.8"
 xmltree = "0.12.0"
+roxmltree = "0.21.1"
+quick-xml = "0.39.2"
 
 [dev-dependencies]
 wiremock = "0.6.5"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -373,7 +373,6 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "reqwest",
- "roxmltree",
  "tokio",
 ]
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -344,7 +344,9 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
+ "quick-xml",
  "reqwest",
+ "roxmltree",
  "serde",
  "serde_json",
  "sha1",
@@ -371,6 +373,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "reqwest",
+ "roxmltree",
  "tokio",
 ]
 
@@ -1308,6 +1311,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,6 +1495,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -22,7 +22,6 @@ tokio = { version = "1.49.0", features = ["rt"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1", optional = true }
 futures = "0.3.31"
-roxmltree = "0.21.1"
 
 [features]
 openssl-vendored = ["dep:openssl", "dep:openssl-probe"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1.49.0", features = ["rt"] }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1", optional = true }
 futures = "0.3.31"
+roxmltree = "0.21.1"
 
 [features]
 openssl-vendored = ["dep:openssl", "dep:openssl-probe"]

--- a/python/datahugger/__init__.py
+++ b/python/datahugger/__init__.py
@@ -7,6 +7,7 @@ from .datahugger import (
     DataverseJsonSrcDataset,
     ZenodoJsonSrcDataset,
     HalJsonSrcDataset,
+    DabarXmlSrcDataset,
 )
 
 __all__ = (
@@ -15,6 +16,7 @@ __all__ = (
     "DataverseJsonSrcDataset",
     "ZenodoJsonSrcDataset",
     "HalJsonSrcDataset",
+    "DabarXmlSrcDataset",
     "DirEntry",
     "FileEntry",
     "Dataset",

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -95,7 +95,7 @@ class DabarXmlSrcDataset(Dataset):
 
         Args:
             id: The DABAR dataset ID, e.g., agr:2814
-            content: The JSON content as a string
+            content: The XML content as a string
 
         Raises:
             RuntimeError

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -84,6 +84,23 @@ class HalJsonSrcDataset(Dataset):
             RuntimeError
         """
 
+class DabarXmlSrcDataset(Dataset):
+    """
+    A HAL dataset backend that uses pre-fetched JSON content.
+    """
+
+    def __init__(self, id: str, content: str) -> None:
+        """
+        Create a new DabarXmlSrcDataset.
+
+        Args:
+            id: The DABAR dataset ID, e.g., agr:2814
+            content: The JSON content as a string
+
+        Raises:
+            RuntimeError
+        """
+
 class Dataset(object):
     def download_with_validation(self, dst_dir: pathlib.Path, limit: int = 0) -> None:
         """blocking call, using rust's async runtime"""

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -86,7 +86,7 @@ class HalJsonSrcDataset(Dataset):
 
 class DabarXmlSrcDataset(Dataset):
     """
-    A HAL dataset backend that uses pre-fetched JSON content.
+    A DABAR MODS dataset backend that uses pre-fetched XML content.
     """
 
     def __init__(self, id: str, content: str) -> None:

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -17,7 +17,7 @@ pub fn main() {
     probe_ssl_certs();
 }
 
-use datahugger::datasets::ZenodoJsonSrcDataset;
+use datahugger::datasets::{DabarXmlSrcDataset, ZenodoJsonSrcDataset};
 use datahugger::datasets::{DataverseJsonSrcDataset, HalJsonSrcDataset};
 use datahugger::{
     crawl,
@@ -203,6 +203,38 @@ impl PyHalJsonSrcDataset {
     fn new(id: String, content: String) -> PyResult<Self> {
         let ds = Dataset {
             backend: Arc::new(HalJsonSrcDataset::new(id, content)),
+        };
+        Ok(Self {
+            inner: PyDataset(ds),
+        })
+    }
+
+    fn crawl_file(&self) -> PyResult<PyFileMetaStream> {
+        let user_agent = format!("datahugger-py/{}", env!("CARGO_PKG_VERSION"));
+        let client = ClientBuilder::new()
+            .user_agent(user_agent)
+            .build()
+            .map_err(|err| PyRuntimeError::new_err(format!("http client fail: {err}")))?;
+        let mp = NoProgress;
+
+        let stream = self.inner.0.clone().crawl_file(&client, mp);
+        let stream = PyFileMetaStream::new(stream);
+        Ok(stream)
+    }
+}
+
+#[pyclass]
+#[pyo3(name = "DabarXmlSrcDataset")]
+struct PyDabarXmlSrcDataset {
+    inner: PyDataset,
+}
+
+#[pymethods]
+impl PyDabarXmlSrcDataset {
+    #[new]
+    fn new(id: String, content: String) -> PyResult<Self> {
+        let ds = Dataset {
+            backend: Arc::new(DabarXmlSrcDataset::new(id, content)),
         };
         Ok(Self {
             inner: PyDataset(ds),
@@ -656,6 +688,7 @@ fn datahuggerpy(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyDataverseJsonSrcDataset>()?;
     m.add_class::<PyZenodoJsonSrcDataset>()?;
     m.add_class::<PyHalJsonSrcDataset>()?;
+    m.add_class::<PyDabarXmlSrcDataset>()?;
 
     // Dir
     let dir = py.get_type::<PyDirEntry>();

--- a/python/tests/test_default.py
+++ b/python/tests/test_default.py
@@ -9,6 +9,7 @@ from datahugger import (
     DataverseJsonSrcDataset,
     ZenodoJsonSrcDataset,
     HalJsonSrcDataset,
+    DabarXmlSrcDataset,
 )
 import requests
 
@@ -170,6 +171,27 @@ def test_hal_from_json():
 
     for i in ds.crawl_file():
         print(i)
+
+
+def test_dabar_from_xml():
+    try:
+        response = requests.get(
+            "https://dabar.srce.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:dabar.srce.hr:biotechri_715",
+            timeout=60,
+        )
+        response.raise_for_status()
+        dabar = response.text
+
+    except Exception as e:
+        print("fetching JSON failed")
+        raise e
+
+    ds = DabarXmlSrcDataset("", dabar)
+
+    for i in ds.crawl_file():
+        print(i)
+
+    # print(dabar)
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_default.py
+++ b/python/tests/test_default.py
@@ -173,7 +173,7 @@ def test_hal_from_json():
         print(i)
 
 
-def test_dabar_from_xml():
+def test_dabar_from_xml1():
     try:
         response = requests.get(
             "https://dabar.srce.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:dabar.srce.hr:biotechri_715",
@@ -191,7 +191,24 @@ def test_dabar_from_xml():
     for i in ds.crawl_file():
         print(i)
 
-    # print(dabar)
+
+def test_dabar_from_xml2():
+    try:
+        response = requests.get(
+            "https://data.fulir.irb.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:data.fulir.irb.hr:irb_106",
+            timeout=60,
+        )
+        response.raise_for_status()
+        dabar = response.text
+
+    except Exception as e:
+        print("fetching JSON failed")
+        raise e
+
+    ds = DabarXmlSrcDataset("", dabar)
+
+    for i in ds.crawl_file():
+        print(i)
 
 
 @pytest.mark.asyncio

--- a/python/tests/test_default.py
+++ b/python/tests/test_default.py
@@ -186,7 +186,7 @@ def test_dabar_from_xml1():
         print("fetching JSON failed")
         raise e
 
-    ds = DabarXmlSrcDataset("", dabar)
+    ds = DabarXmlSrcDataset("biotechri:715", dabar)
 
     for i in ds.crawl_file():
         print(i)
@@ -205,7 +205,7 @@ def test_dabar_from_xml2():
         print("fetching JSON failed")
         raise e
 
-    ds = DabarXmlSrcDataset("", dabar)
+    ds = DabarXmlSrcDataset("irb:106", dabar)
 
     for i in ds.crawl_file():
         print(i)

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -135,7 +135,7 @@ impl DabarXmlSrcDataset {
     pub fn new(id: impl Into<String>, content: String) -> Self {
         DabarXmlSrcDataset {
             id: id.into(),
-            content: content,
+            content,
         }
     }
 }
@@ -147,7 +147,7 @@ impl DatasetBackend for DabarXmlSrcDataset {
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
-        let doc = roxmltree::Document::parse(self.content.as_str()).or_raise(|| RepoError {
+        let doc = roxmltree::Document::parse(&self.content).or_raise(|| RepoError {
             message: "Failed to parse XML".to_string(),
         })?;
 

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -64,7 +64,7 @@ fn make_file_entry(
 
     let endpoint = Endpoint {
         parent_url: dir.api_url(),
-        key: Some(format!("")), // TODO: fix this
+        key: None, // TODO: figure out how to use this in local data analyzer use case
     };
 
     Ok(Entry::File(FileMeta::new(
@@ -150,7 +150,7 @@ impl DabarXmlSrcDataset {
 #[async_trait]
 impl DatasetBackend for DabarXmlSrcDataset {
     fn root_url(&self) -> Url {
-        Url::parse("https://example.com").unwrap() // TODO: fix this
+        Url::parse("https://dabar.srce.hr/oai/").unwrap() // static OAI-PMH repo URL
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
@@ -178,6 +178,8 @@ impl DatasetBackend for DabarXmlSrcDataset {
             })
         })?;
 
+        // Build a client to resolve the URL handle to figure out the domain to build the download links.
+        // TODO: Once DABAR MODS contains the domains, this logic can be removed.
         let no_redirect_client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .build()

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -127,7 +127,7 @@ fn analyze_xml(
 #[derive(Debug)]
 pub struct DabarXmlSrcDataset {
     pub id: String,
-    pub content: &'static str,
+    pub content: String,
 }
 
 impl DabarXmlSrcDataset {
@@ -135,7 +135,7 @@ impl DabarXmlSrcDataset {
     pub fn new(id: impl Into<String>, content: String) -> Self {
         DabarXmlSrcDataset {
             id: id.into(),
-            content: Box::leak(content.into_boxed_str()),
+            content: content,
         }
     }
 }
@@ -147,7 +147,7 @@ impl DatasetBackend for DabarXmlSrcDataset {
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
-        let doc = roxmltree::Document::parse(self.content).or_raise(|| RepoError {
+        let doc = roxmltree::Document::parse(self.content.as_str()).or_raise(|| RepoError {
             message: "Failed to parse XML".to_string(),
         })?;
 

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -4,20 +4,15 @@ use async_trait::async_trait;
 use exn::{Exn, ResultExt};
 use url::Url;
 
-use crate::helper::{json_extract, json_extract_opt};
 use crate::{
     repo::{Endpoint, FileMeta, RepoError},
     DatasetBackend, DirMeta, Entry,
 };
 use mime::Mime;
-use reqwest::{Client, StatusCode};
-use std::{any::Any, str::FromStr};
-
-use quick_xml::events::Event;
-use quick_xml::Reader;
+use reqwest::Client;
+use std::any::Any;
 
 // Namespace constants mirroring Python's NS dict
-const NS_OAI: &str = "http://www.openarchives.org/OAI/2.0/";
 const NS_MODS: &str = "http://www.loc.gov/mods/v3";
 
 fn make_file_entry(
@@ -26,14 +21,11 @@ fn make_file_entry(
     location: &str,
     dir: &DirMeta,
 ) -> Result<Entry, Exn<RepoError>> {
-    let file_identifier = file_meta
-        .attribute("ID")
-        .ok_or_else(|| RepoError {
+    let file_identifier = file_meta.attribute("ID").ok_or_else(|| {
+        Exn::new(RepoError {
             message: "file_meta element missing ID attribute".to_string(),
         })
-        .or_raise(|| RepoError {
-            message: "file_meta element missing ID attribute".to_string(),
-        })?;
+    })?;
 
     // mods:physicalDescription/mods:internetMediaType
     let mime_text = file_meta
@@ -42,25 +34,21 @@ fn make_file_entry(
             n.tag_name().name() == "internetMediaType" && n.tag_name().namespace() == Some(NS_MODS)
         })
         .and_then(|n| n.text())
-        .ok_or_else(|| RepoError {
-            message: format!("No mimetype found for file_meta ID={file_identifier}"),
-        })
-        .or_raise(|| RepoError {
-            message: format!("No mimetype found for file_meta ID={file_identifier}"),
+        .ok_or_else(|| {
+            Exn::new(RepoError {
+                message: format!("No mimetype found for file_meta ID={file_identifier}"),
+            })
         })?;
 
     let mime: Mime = mime_text.parse::<Mime>().or_raise(|| RepoError {
         message: format!("Invalid mimetype: {mime_text}"),
     })?;
 
-    let record_id_text = record_identifier
-        .text()
-        .ok_or_else(|| RepoError {
+    let record_id_text = record_identifier.text().ok_or_else(|| {
+        Exn::new(RepoError {
             message: "record identifier has no text content".to_string(),
         })
-        .or_raise(|| RepoError {
-            message: "record identifier has no text content".to_string(),
-        })?;
+    })?;
 
     let download_url: Url = format!("{location}/{file_identifier}/download")
         .parse::<Url>()
@@ -171,23 +159,17 @@ impl DatasetBackend for DabarXmlSrcDataset {
                     && n.tag_name().namespace() == Some(NS_MODS)
                     && n.attribute("displayLabel") == Some("URN:NBN")
             })
-            .ok_or_else(|| RepoError {
-                message: "No location url (URN:NBN) found in record".to_string(),
-            })
-            .or_raise(|| RepoError {
-                message: "No location url (URN:NBN) found in record".to_string(),
+            .ok_or_else(|| {
+                Exn::new(RepoError {
+                    message: "No location url (URN:NBN) found in record".to_string(),
+                })
             })?;
 
-        let urn_url_text = urn_url_node
-            .text()
-            .ok_or_else(|| RepoError {
+        let urn_url_text = urn_url_node.text().ok_or_else(|| {
+            Exn::new(RepoError {
                 message: "URN:NBN url node has no text".to_string(),
             })
-            .or_raise(|| RepoError {
-                message: "URN:NBN url node has no text".to_string(),
-            })?;
-
-        //println!("{}", urn_url_text);
+        })?;
 
         let no_redirect_client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())
@@ -207,11 +189,10 @@ impl DatasetBackend for DabarXmlSrcDataset {
         let location = response
             .headers()
             .get("Location")
-            .ok_or_else(|| RepoError {
-                message: "No location header in response".to_string(),
-            })
-            .or_raise(|| RepoError {
-                message: "No location header in response".to_string(),
+            .ok_or_else(|| {
+                Exn::new(RepoError {
+                    message: "No location header in response".to_string(),
+                })
             })?
             .to_str()
             .or_raise(|| RepoError {

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -1,0 +1,624 @@
+#![allow(clippy::upper_case_acronyms)]
+
+use async_trait::async_trait;
+use exn::{Exn, ResultExt};
+use url::Url;
+
+use reqwest::{Client, StatusCode};
+use std::{any::Any, str::FromStr};
+use mime::Mime;
+use crate::helper::{json_extract, json_extract_opt};
+use crate::{
+    repo::{Endpoint, FileMeta, RepoError},
+    DatasetBackend, DirMeta, Entry,
+};
+
+use quick_xml::Reader;
+use quick_xml::events::Event;
+
+// Namespace constants mirroring Python's NS dict
+const NS_OAI: &str = "http://www.openarchives.org/OAI/2.0/";
+const NS_MODS: &str = "http://www.loc.gov/mods/v3";
+
+fn make_file_entry(
+    file_meta: &roxmltree::Node,
+    record_identifier: &roxmltree::Node,
+    location: &str,
+    dir: &DirMeta,
+) -> Result<Entry, Exn<RepoError>> {
+    let file_identifier = file_meta.attribute("ID")
+        .ok_or_else(
+            || RepoError {
+                message: "file_meta element missing ID attribute".to_string(),
+            }
+        )
+        .or_raise(|| RepoError {
+        message: "file_meta element missing ID attribute".to_string(),
+    })?;
+
+    // mods:physicalDescription/mods:internetMediaType
+    let mime_text = file_meta
+        .descendants()
+        .find(|n| {
+            n.tag_name().name() == "internetMediaType"
+                && n.tag_name().namespace() == Some(NS_MODS)
+        })
+        .and_then(|n| n.text())
+        .ok_or_else(
+            || RepoError {
+                message: format!("No mimetype found for file_meta ID={file_identifier}"),
+            }
+        )
+        .or_raise(|| RepoError {
+            message: format!("No mimetype found for file_meta ID={file_identifier}"),
+        })?;
+
+    let mime: Mime = mime_text.parse::<Mime>()
+        .or_raise(|| RepoError {
+        message: format!("Invalid mimetype: {mime_text}"),
+    })?;
+
+    let record_id_text = record_identifier.text()
+        .ok_or_else(
+            || RepoError {
+                message: "record identifier has no text content".to_string(),
+            }
+        )
+        .or_raise(|| RepoError {
+        message: "record identifier has no text content".to_string(),
+    })?;
+
+    let download_url: Url = format!("{location}/{file_identifier}/download")
+        .parse::<Url>()
+        .or_raise(|| RepoError {
+            message: format!("Could not build download URL for identifier={record_id_text}"),
+        })?;
+
+    let endpoint = Endpoint {
+        parent_url: dir.api_url(),
+        key: Some(format!("")),
+    };
+
+    Ok(Entry::File(FileMeta::new(
+        None,
+        Some(file_identifier.to_string()),
+        dir.join(""),       // adjust to your CrawlPath construction
+        endpoint, // adjust to your Endpoint construction
+        download_url,
+        None,
+        vec![],
+        Some(mime),
+        None,
+        None,
+        None,
+        true,
+    )))
+}
+
+fn analyze_xml(doc: &roxmltree::Document, dir: &DirMeta, location: &str) -> Result<Vec<Entry>, Exn<RepoError>>  {
+    let root = doc.root_element();
+
+    // /oai:record/oai:metadata//mods:identifier[@type="local"]
+    let record_identifier = root
+        .descendants()
+        .find(|n| {
+            n.tag_name().name() == "identifier"
+                && n.tag_name().namespace() == Some(NS_MODS)
+                && n.attribute("type") == Some("local")
+        });
+
+    // /oai:record/oai:metadata//mods:location/mods:url
+    let record_url = root
+        .descendants()
+        .find(|n| {
+            n.tag_name().name() == "url"
+                && n.tag_name().namespace() == Some(NS_MODS)
+        });
+
+    // Early return `
+    if record_identifier.is_none() || record_url.is_none() {
+        return Ok(vec![]);
+    }
+
+    let record_identifier = record_identifier.unwrap();
+
+    //println!("{:?}", record_identifier.and_then(|n| n.text()));
+    //println!("{}", urn_url_text);
+
+
+    // /oai:record/oai:metadata//mods:mods[mods:physicalDescription/mods:internetMediaType]
+    let file_metas: Vec<_> = root
+        .descendants()
+        .filter(|n| {
+            n.tag_name().name() == "mods"
+                && n.tag_name().namespace() == Some(NS_MODS)
+                && n.descendants().any(|child| {
+                child.tag_name().name() == "internetMediaType"
+                    && child.tag_name().namespace() == Some(NS_MODS)
+            })
+        })
+        .collect();
+
+    let entries = file_metas
+        .iter()
+        .map(|file_meta| make_file_entry(file_meta, &record_identifier, &location, dir))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(entries)
+
+
+}
+
+#[derive(Debug)]
+pub struct DabarXmlSrcDataset {
+    pub id: String,
+    pub content: &'static str,
+}
+
+impl DabarXmlSrcDataset {
+    #[must_use]
+    pub fn new(id: impl Into<String>, content: String) -> Self {
+        DabarXmlSrcDataset { id: id.into(), content: Box::leak(content.into_boxed_str()) }
+    }
+}
+
+#[async_trait]
+impl DatasetBackend for DabarXmlSrcDataset {
+    fn root_url(&self) -> Url {
+        todo!()
+    }
+
+    async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
+        let doc = roxmltree::Document::parse(self.content).or_raise(|| RepoError {
+            message: "Failed to parse XML".to_string(),
+        })?;
+
+        // /oai:record/oai:metadata//mods:location/mods:url[@displayLabel="URN:NBN"]
+        let urn_url_node = doc
+            .descendants()
+            .find(|n| {
+                n.tag_name().name() == "url"
+                    && n.tag_name().namespace() == Some(NS_MODS)
+                    && n.attribute("displayLabel") == Some("URN:NBN")
+            })
+            .ok_or_else(|| RepoError {
+                message: "No location url (URN:NBN) found in record".to_string(),
+            })
+            .or_raise(|| RepoError {
+                message: "No location url (URN:NBN) found in record".to_string(),
+            })?;
+
+        let urn_url_text = urn_url_node.text()
+            .ok_or_else(|| RepoError {
+                message: "URN:NBN url node has no text".to_string(),
+            })
+            .or_raise(|| RepoError {
+                message: "URN:NBN url node has no text".to_string(),
+            })?;
+
+        println!("{}", urn_url_text);
+
+        let no_redirect_client = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .or_raise(|| RepoError {
+                message: "Failed to build HTTP client".to_string(),
+            })?;
+
+        let response = no_redirect_client.head(urn_url_text).send().await.or_raise(|| RepoError {
+            message: format!("HEAD request failed for {urn_url_text}"),
+        })?;
+
+        let location = response
+            .headers()
+            .get("Location")
+            .ok_or_else(|| RepoError {
+                message: "No location header in response".to_string(),
+            })
+            .or_raise(|| RepoError {
+                message: "No location header in response".to_string(),
+            })?
+            .to_str()
+            .or_raise(|| RepoError {
+                message: "Location header is not valid UTF-8".to_string(),
+            })?
+            .to_string();
+
+        println!("{}", location);
+
+
+        let entries = analyze_xml(&doc, &dir, &location)?;
+
+        Ok(entries)
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CrawlPath;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_list() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <header>
+    <identifier>oai:dabar.srce.hr:agr_2814</identifier>
+    <datestamp>2025-10-27</datestamp>
+  </header>
+  <metadata>
+    <modsCollection xmlns="http://www.loc.gov/mods/v3" xmlns:dabar="http://dabar.srce.hr/standards/schema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:etd="http://www.ndltd.org/standards/metadata/etdms/1.0" xmlns:datacite="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-8.xsd http://dabar.srce.hr/standards/schema/1.0 https://dabar.srce.hr/standards/schema/1.0/dabar.xsd">
+      <mods ID="master" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <identifier type="local">agr:2814</identifier>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Lana</namePart>
+          <namePart type="family">Filipović</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Vilim</namePart>
+          <namePart type="family">Filipović</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Zoran</namePart>
+          <namePart type="family">Kovač</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Vedran</namePart>
+          <namePart type="family">Krevh</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Jasmina</namePart>
+          <namePart type="family">Defterdarović</namePart>
+        </name>
+        <titleInfo lang="eng" usage="primary">
+          <title>SUPREHILL Critical Zone Observatory dataset - funded by Croatian Science Foundation (HRZZ)</title>
+        </titleInfo>
+        <language>
+          <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+        </language>
+        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="hrv" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">eksperimentalni podaci</genre>
+        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="eng" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">experimental data</genre>
+        <genre authority="coar" authorityURI="https://vocabularies.coar-repositories.org/resource_types/" valueURI="http://purl.org/coar/resource_type/63NG-B465">experimental data</genre>
+        <abstract lang="eng" type="primary">Data collected at the SUPREHILL Critical Zone Observatory (CZO), funded by Croatian Science Foundation (HRZZ)</abstract>
+        <subject lang="eng" usage="primary">
+          <topic>SUPREHILL</topic>
+          <topic>critical zone observatory</topic>
+          <topic>vadose zone</topic>
+          <topic>hillslope</topic>
+          <topic>vineyard</topic>
+        </subject>
+        <subject authority="nvzz.hr" ID="4#4.01#4.01.03">
+          <topic lang="hrv">Biotehničke znanosti</topic>
+          <topic lang="eng">Biotechnical Sciences</topic>
+          <topic lang="hrv">Poljoprivreda</topic>
+          <topic lang="eng">Agriculture</topic>
+          <topic lang="hrv">ekologija i zaštita okoliša</topic>
+          <topic lang="eng">Ecology and Environmental Protection</topic>
+        </subject>
+        <relatedItem type="constituent" displayLabel="project">
+          <identifier type="local">4284</identifier>
+          <identifier>UIP-2019-04-5409</identifier>
+          <titleInfo lang="hrv">
+            <title>Podpovršinski preferencijalni transportni procesi u poljoprivrednim padinskim tlima</title>
+          </titleInfo>
+          <titleInfo lang="eng">
+            <title>SUbsurface PREferential transport processes in agricultural HILLslope soils</title>
+          </titleInfo>
+          <name type="personal">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pdr">project director</roleTerm>
+              <roleTerm lang="hrv" type="text">Voditelj projekta</roleTerm>
+            </role>
+            <namePart>Vilim Filipović</namePart>
+          </name>
+          <name type="corporate" authority="iso3166">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/jug">jurisdiction governed</roleTerm>
+            </role>
+            <namePart>Hrvatska</namePart>
+          </name>
+          <name type="corporate">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
+            </role>
+            <namePart displayLabel="funder name">Hrvatska zaklada za znanost</namePart>
+          </name>
+          <note type="funding" displayLabel="funder programme">Installation Research Projects</note>
+          <titleInfo type="abbreviated">
+            <title>SUPREHILL</title>
+          </titleInfo>
+        </relatedItem>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+        <physicalDescription/>
+        <physicalDescription/>
+        <physicalDescription/>
+        <subject>
+          <geographic authority="iso3166">HR</geographic>
+          <geographic>Jazbina</geographic>
+        </subject>
+        <abstract type="methods" lang="eng">Data collected at the SUPREHILL CZO (https://sites.google.com/view/suprehill) is separated into three main categories.: 1) data collected by field measurements 2) data collected by individual field and laboratory experiments 3) data collected by laboratory analyses</abstract>
+        <name type="corporate">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pbl">publisher</roleTerm>
+            <roleTerm type="text" lang="hrv">izdavač</roleTerm>
+          </role>
+          <namePart lang="hrv">Agronomski fakultet</namePart>
+          <namePart lang="eng">Faculty of Agriculture</namePart>
+        </name>
+        <location>
+          <url access="object in context" usage="primary" displayLabel="URN:NBN">https://urn.nsk.hr/urn:nbn:hr:204:468943</url>
+        </location>
+        <identifier type="urn">urn:nbn:hr:204:468943</identifier>
+        <recordInfo>
+          <recordIdentifier>agr:2814/mods:2023-02-22T12:55:29+01:00</recordIdentifier>
+          <recordCreationDate encoding="iso8601">2023-02-22T12:55:29+01:00</recordCreationDate>
+          <recordContentSource authority="local">agr</recordContentSource>
+          <recordContentSource>Repozitorij Agronomskog fakulteta u Zagrebu</recordContentSource>
+          <recordChangeDate encoding="iso8601">2024-02-27T13:54:10+01:00</recordChangeDate>
+        </recordInfo>
+        <name type="personal">
+          <namePart type="given">Lana</namePart>
+          <namePart type="family">Filipović</namePart>
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dtc">data contributor</roleTerm>
+            <roleTerm type="text" lang="hrv">Djelatnik</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart type="given">Valentina</namePart>
+          <namePart type="family">Bezek</namePart>
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/edt">editor</roleTerm>
+            <roleTerm type="text">data editor</roleTerm>
+          </role>
+        </name>
+        <genre authority="dabar" type="object type">dataset</genre>
+        <extension>
+          <dabar:kontaktZaCjelovitiTekst>lfilipovic@agr.hr</dabar:kontaktZaCjelovitiTekst>
+        </extension>
+      </mods>
+      <mods ID="FILE0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <physicalDescription>
+          <internetMediaType>application/zip</internetMediaType>
+        </physicalDescription>
+        <abstract displayLabel="data description" lang="eng">SUPREHILL database</abstract>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+        <identifier type="file">primary file</identifier>
+      </mods>
+      <mods ID="DOC0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <physicalDescription>
+          <internetMediaType>application/vnd.openxmlformats-officedocument.wordprocessingml.document</internetMediaType>
+        </physicalDescription>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+      </mods>
+    </modsCollection>
+  </metadata>
+</record>"#;
+
+        let dataset = DabarXmlSrcDataset::new("test-id", xml.to_string());
+        let client = Client::new();
+        let dir = DirMeta::new(
+            CrawlPath::root(),
+            Url::parse("https://example.com/api").unwrap(),
+            Url::parse("https://example.com").unwrap(),
+        );
+
+        let entries = dataset.list(&client, dir).await.unwrap();
+
+        assert_eq!(entries.len(), 0);
+    }
+
+    #[test]
+    fn test_analyze_xml() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <header>
+    <identifier>oai:dabar.srce.hr:agr_2814</identifier>
+    <datestamp>2025-10-27</datestamp>
+  </header>
+  <metadata>
+    <modsCollection xmlns="http://www.loc.gov/mods/v3" xmlns:dabar="http://dabar.srce.hr/standards/schema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:etd="http://www.ndltd.org/standards/metadata/etdms/1.0" xmlns:datacite="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-8.xsd http://dabar.srce.hr/standards/schema/1.0 https://dabar.srce.hr/standards/schema/1.0/dabar.xsd">
+      <mods ID="master" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <identifier type="local">agr:2814</identifier>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Lana</namePart>
+          <namePart type="family">Filipović</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Vilim</namePart>
+          <namePart type="family">Filipović</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Zoran</namePart>
+          <namePart type="family">Kovač</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Vedran</namePart>
+          <namePart type="family">Krevh</namePart>
+        </name>
+        <name type="personal">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+          </role>
+          <namePart type="given">Jasmina</namePart>
+          <namePart type="family">Defterdarović</namePart>
+        </name>
+        <titleInfo lang="eng" usage="primary">
+          <title>SUPREHILL Critical Zone Observatory dataset - funded by Croatian Science Foundation (HRZZ)</title>
+        </titleInfo>
+        <language>
+          <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+        </language>
+        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="hrv" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">eksperimentalni podaci</genre>
+        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="eng" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">experimental data</genre>
+        <genre authority="coar" authorityURI="https://vocabularies.coar-repositories.org/resource_types/" valueURI="http://purl.org/coar/resource_type/63NG-B465">experimental data</genre>
+        <abstract lang="eng" type="primary">Data collected at the SUPREHILL Critical Zone Observatory (CZO), funded by Croatian Science Foundation (HRZZ)</abstract>
+        <subject lang="eng" usage="primary">
+          <topic>SUPREHILL</topic>
+          <topic>critical zone observatory</topic>
+          <topic>vadose zone</topic>
+          <topic>hillslope</topic>
+          <topic>vineyard</topic>
+        </subject>
+        <subject authority="nvzz.hr" ID="4#4.01#4.01.03">
+          <topic lang="hrv">Biotehničke znanosti</topic>
+          <topic lang="eng">Biotechnical Sciences</topic>
+          <topic lang="hrv">Poljoprivreda</topic>
+          <topic lang="eng">Agriculture</topic>
+          <topic lang="hrv">ekologija i zaštita okoliša</topic>
+          <topic lang="eng">Ecology and Environmental Protection</topic>
+        </subject>
+        <relatedItem type="constituent" displayLabel="project">
+          <identifier type="local">4284</identifier>
+          <identifier>UIP-2019-04-5409</identifier>
+          <titleInfo lang="hrv">
+            <title>Podpovršinski preferencijalni transportni procesi u poljoprivrednim padinskim tlima</title>
+          </titleInfo>
+          <titleInfo lang="eng">
+            <title>SUbsurface PREferential transport processes in agricultural HILLslope soils</title>
+          </titleInfo>
+          <name type="personal">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pdr">project director</roleTerm>
+              <roleTerm lang="hrv" type="text">Voditelj projekta</roleTerm>
+            </role>
+            <namePart>Vilim Filipović</namePart>
+          </name>
+          <name type="corporate" authority="iso3166">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/jug">jurisdiction governed</roleTerm>
+            </role>
+            <namePart>Hrvatska</namePart>
+          </name>
+          <name type="corporate">
+            <role>
+              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
+            </role>
+            <namePart displayLabel="funder name">Hrvatska zaklada za znanost</namePart>
+          </name>
+          <note type="funding" displayLabel="funder programme">Installation Research Projects</note>
+          <titleInfo type="abbreviated">
+            <title>SUPREHILL</title>
+          </titleInfo>
+        </relatedItem>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+        <physicalDescription/>
+        <physicalDescription/>
+        <physicalDescription/>
+        <subject>
+          <geographic authority="iso3166">HR</geographic>
+          <geographic>Jazbina</geographic>
+        </subject>
+        <abstract type="methods" lang="eng">Data collected at the SUPREHILL CZO (https://sites.google.com/view/suprehill) is separated into three main categories.: 1) data collected by field measurements 2) data collected by individual field and laboratory experiments 3) data collected by laboratory analyses</abstract>
+        <name type="corporate">
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pbl">publisher</roleTerm>
+            <roleTerm type="text" lang="hrv">izdavač</roleTerm>
+          </role>
+          <namePart lang="hrv">Agronomski fakultet</namePart>
+          <namePart lang="eng">Faculty of Agriculture</namePart>
+        </name>
+        <location>
+          <url access="object in context" usage="primary" displayLabel="URN:NBN">https://urn.nsk.hr/urn:nbn:hr:204:468943</url>
+        </location>
+        <identifier type="urn">urn:nbn:hr:204:468943</identifier>
+        <recordInfo>
+          <recordIdentifier>agr:2814/mods:2023-02-22T12:55:29+01:00</recordIdentifier>
+          <recordCreationDate encoding="iso8601">2023-02-22T12:55:29+01:00</recordCreationDate>
+          <recordContentSource authority="local">agr</recordContentSource>
+          <recordContentSource>Repozitorij Agronomskog fakulteta u Zagrebu</recordContentSource>
+          <recordChangeDate encoding="iso8601">2024-02-27T13:54:10+01:00</recordChangeDate>
+        </recordInfo>
+        <name type="personal">
+          <namePart type="given">Lana</namePart>
+          <namePart type="family">Filipović</namePart>
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dtc">data contributor</roleTerm>
+            <roleTerm type="text" lang="hrv">Djelatnik</roleTerm>
+          </role>
+        </name>
+        <name type="personal">
+          <namePart type="given">Valentina</namePart>
+          <namePart type="family">Bezek</namePart>
+          <role>
+            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/edt">editor</roleTerm>
+            <roleTerm type="text">data editor</roleTerm>
+          </role>
+        </name>
+        <genre authority="dabar" type="object type">dataset</genre>
+        <extension>
+          <dabar:kontaktZaCjelovitiTekst>lfilipovic@agr.hr</dabar:kontaktZaCjelovitiTekst>
+        </extension>
+      </mods>
+      <mods ID="FILE0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <physicalDescription>
+          <internetMediaType>application/zip</internetMediaType>
+        </physicalDescription>
+        <abstract displayLabel="data description" lang="eng">SUPREHILL database</abstract>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+        <identifier type="file">primary file</identifier>
+      </mods>
+      <mods ID="DOC0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+        <physicalDescription>
+          <internetMediaType>application/vnd.openxmlformats-officedocument.wordprocessingml.document</internetMediaType>
+        </physicalDescription>
+        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+      </mods>
+    </modsCollection>
+  </metadata>
+</record>
+"#;
+
+        let doc = roxmltree::Document::parse(xml).unwrap();
+        let dir = DirMeta::new(
+            CrawlPath::root(),
+            Url::parse("https://example.com/api").unwrap(),
+            Url::parse("https://example.com").unwrap(),
+        );
+
+        let location = "https://repozitorij.agr.unizg.hr/object/agr:2814";
+
+        let entries = analyze_xml(&doc, &dir, &location).unwrap();
+
+        println!("{:?}", entries);
+
+        assert_eq!(entries.len(), 0);
+    }
+}

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -44,6 +44,12 @@ fn make_file_entry(
         message: format!("Invalid mimetype: {mime_text}"),
     })?;
 
+    let size: Option<u64> = file_meta
+        .descendants()
+        .find(|n| n.tag_name().name() == "extent" && n.tag_name().namespace() == Some(NS_MODS))
+        .and_then(|n| n.text())
+        .and_then(|s| s.parse::<u64>().ok());
+
     let record_id_text = record_identifier.text().ok_or_else(|| {
         Exn::new(RepoError {
             message: "record identifier has no text content".to_string(),
@@ -67,7 +73,7 @@ fn make_file_entry(
         dir.join(""), // adjust to your CrawlPath construction
         endpoint,     // adjust to your Endpoint construction
         download_url,
-        None,
+        size,
         vec![],
         Some(mime),
         None,
@@ -109,6 +115,7 @@ fn analyze_xml(
         .filter(|n| {
             n.tag_name().name() == "mods"
                 && n.tag_name().namespace() == Some(NS_MODS)
+                && n.attribute("ID") != Some("master")
                 && n.descendants().any(|child| {
                     child.tag_name().name() == "internetMediaType"
                         && child.tag_name().namespace() == Some(NS_MODS)
@@ -199,8 +206,6 @@ impl DatasetBackend for DabarXmlSrcDataset {
                 message: "Location header is not valid UTF-8".to_string(),
             })?
             .to_string();
-
-        println!("{}", location);
 
         let entries = analyze_xml(&doc, &dir, &location)?;
 

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -115,9 +115,6 @@ fn analyze_xml(
 
     let record_identifier = record_identifier.unwrap();
 
-    //println!("{:?}", record_identifier.and_then(|n| n.text()));
-    //println!("{}", urn_url_text);
-
     // /oai:record/oai:metadata//mods:mods[mods:physicalDescription/mods:internetMediaType]
     let file_metas: Vec<_> = root
         .descendants()
@@ -158,10 +155,10 @@ impl DabarXmlSrcDataset {
 #[async_trait]
 impl DatasetBackend for DabarXmlSrcDataset {
     fn root_url(&self) -> Url {
-        todo!()
+        Url::parse("https://example.com").unwrap() // TODO: fix this
     }
 
-    async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
+    async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let doc = roxmltree::Document::parse(self.content).or_raise(|| RepoError {
             message: "Failed to parse XML".to_string(),
         })?;
@@ -190,7 +187,7 @@ impl DatasetBackend for DabarXmlSrcDataset {
                 message: "URN:NBN url node has no text".to_string(),
             })?;
 
-        println!("{}", urn_url_text);
+        //println!("{}", urn_url_text);
 
         let no_redirect_client = Client::builder()
             .redirect(reqwest::redirect::Policy::none())

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -4,17 +4,17 @@ use async_trait::async_trait;
 use exn::{Exn, ResultExt};
 use url::Url;
 
-use reqwest::{Client, StatusCode};
-use std::{any::Any, str::FromStr};
-use mime::Mime;
 use crate::helper::{json_extract, json_extract_opt};
 use crate::{
     repo::{Endpoint, FileMeta, RepoError},
     DatasetBackend, DirMeta, Entry,
 };
+use mime::Mime;
+use reqwest::{Client, StatusCode};
+use std::{any::Any, str::FromStr};
 
-use quick_xml::Reader;
 use quick_xml::events::Event;
+use quick_xml::Reader;
 
 // Namespace constants mirroring Python's NS dict
 const NS_OAI: &str = "http://www.openarchives.org/OAI/2.0/";
@@ -26,47 +26,41 @@ fn make_file_entry(
     location: &str,
     dir: &DirMeta,
 ) -> Result<Entry, Exn<RepoError>> {
-    let file_identifier = file_meta.attribute("ID")
-        .ok_or_else(
-            || RepoError {
-                message: "file_meta element missing ID attribute".to_string(),
-            }
-        )
+    let file_identifier = file_meta
+        .attribute("ID")
+        .ok_or_else(|| RepoError {
+            message: "file_meta element missing ID attribute".to_string(),
+        })
         .or_raise(|| RepoError {
-        message: "file_meta element missing ID attribute".to_string(),
-    })?;
+            message: "file_meta element missing ID attribute".to_string(),
+        })?;
 
     // mods:physicalDescription/mods:internetMediaType
     let mime_text = file_meta
         .descendants()
         .find(|n| {
-            n.tag_name().name() == "internetMediaType"
-                && n.tag_name().namespace() == Some(NS_MODS)
+            n.tag_name().name() == "internetMediaType" && n.tag_name().namespace() == Some(NS_MODS)
         })
         .and_then(|n| n.text())
-        .ok_or_else(
-            || RepoError {
-                message: format!("No mimetype found for file_meta ID={file_identifier}"),
-            }
-        )
+        .ok_or_else(|| RepoError {
+            message: format!("No mimetype found for file_meta ID={file_identifier}"),
+        })
         .or_raise(|| RepoError {
             message: format!("No mimetype found for file_meta ID={file_identifier}"),
         })?;
 
-    let mime: Mime = mime_text.parse::<Mime>()
-        .or_raise(|| RepoError {
+    let mime: Mime = mime_text.parse::<Mime>().or_raise(|| RepoError {
         message: format!("Invalid mimetype: {mime_text}"),
     })?;
 
-    let record_id_text = record_identifier.text()
-        .ok_or_else(
-            || RepoError {
-                message: "record identifier has no text content".to_string(),
-            }
-        )
+    let record_id_text = record_identifier
+        .text()
+        .ok_or_else(|| RepoError {
+            message: "record identifier has no text content".to_string(),
+        })
         .or_raise(|| RepoError {
-        message: "record identifier has no text content".to_string(),
-    })?;
+            message: "record identifier has no text content".to_string(),
+        })?;
 
     let download_url: Url = format!("{location}/{file_identifier}/download")
         .parse::<Url>()
@@ -76,14 +70,14 @@ fn make_file_entry(
 
     let endpoint = Endpoint {
         parent_url: dir.api_url(),
-        key: Some(format!("")),
+        key: Some(format!("")), // TODO: fix this
     };
 
     Ok(Entry::File(FileMeta::new(
         None,
         Some(file_identifier.to_string()),
-        dir.join(""),       // adjust to your CrawlPath construction
-        endpoint, // adjust to your Endpoint construction
+        dir.join(""), // adjust to your CrawlPath construction
+        endpoint,     // adjust to your Endpoint construction
         download_url,
         None,
         vec![],
@@ -95,25 +89,24 @@ fn make_file_entry(
     )))
 }
 
-fn analyze_xml(doc: &roxmltree::Document, dir: &DirMeta, location: &str) -> Result<Vec<Entry>, Exn<RepoError>>  {
+fn analyze_xml(
+    doc: &roxmltree::Document,
+    dir: &DirMeta,
+    location: &str,
+) -> Result<Vec<Entry>, Exn<RepoError>> {
     let root = doc.root_element();
 
     // /oai:record/oai:metadata//mods:identifier[@type="local"]
-    let record_identifier = root
-        .descendants()
-        .find(|n| {
-            n.tag_name().name() == "identifier"
-                && n.tag_name().namespace() == Some(NS_MODS)
-                && n.attribute("type") == Some("local")
-        });
+    let record_identifier = root.descendants().find(|n| {
+        n.tag_name().name() == "identifier"
+            && n.tag_name().namespace() == Some(NS_MODS)
+            && n.attribute("type") == Some("local")
+    });
 
     // /oai:record/oai:metadata//mods:location/mods:url
     let record_url = root
         .descendants()
-        .find(|n| {
-            n.tag_name().name() == "url"
-                && n.tag_name().namespace() == Some(NS_MODS)
-        });
+        .find(|n| n.tag_name().name() == "url" && n.tag_name().namespace() == Some(NS_MODS));
 
     // Early return `
     if record_identifier.is_none() || record_url.is_none() {
@@ -125,7 +118,6 @@ fn analyze_xml(doc: &roxmltree::Document, dir: &DirMeta, location: &str) -> Resu
     //println!("{:?}", record_identifier.and_then(|n| n.text()));
     //println!("{}", urn_url_text);
 
-
     // /oai:record/oai:metadata//mods:mods[mods:physicalDescription/mods:internetMediaType]
     let file_metas: Vec<_> = root
         .descendants()
@@ -133,20 +125,18 @@ fn analyze_xml(doc: &roxmltree::Document, dir: &DirMeta, location: &str) -> Resu
             n.tag_name().name() == "mods"
                 && n.tag_name().namespace() == Some(NS_MODS)
                 && n.descendants().any(|child| {
-                child.tag_name().name() == "internetMediaType"
-                    && child.tag_name().namespace() == Some(NS_MODS)
-            })
+                    child.tag_name().name() == "internetMediaType"
+                        && child.tag_name().namespace() == Some(NS_MODS)
+                })
         })
         .collect();
 
     let entries = file_metas
         .iter()
-        .map(|file_meta| make_file_entry(file_meta, &record_identifier, &location, dir))
+        .map(|file_meta| make_file_entry(file_meta, &record_identifier, location, dir))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(entries)
-
-
 }
 
 #[derive(Debug)]
@@ -158,7 +148,10 @@ pub struct DabarXmlSrcDataset {
 impl DabarXmlSrcDataset {
     #[must_use]
     pub fn new(id: impl Into<String>, content: String) -> Self {
-        DabarXmlSrcDataset { id: id.into(), content: Box::leak(content.into_boxed_str()) }
+        DabarXmlSrcDataset {
+            id: id.into(),
+            content: Box::leak(content.into_boxed_str()),
+        }
     }
 }
 
@@ -188,7 +181,8 @@ impl DatasetBackend for DabarXmlSrcDataset {
                 message: "No location url (URN:NBN) found in record".to_string(),
             })?;
 
-        let urn_url_text = urn_url_node.text()
+        let urn_url_text = urn_url_node
+            .text()
             .ok_or_else(|| RepoError {
                 message: "URN:NBN url node has no text".to_string(),
             })
@@ -205,9 +199,13 @@ impl DatasetBackend for DabarXmlSrcDataset {
                 message: "Failed to build HTTP client".to_string(),
             })?;
 
-        let response = no_redirect_client.head(urn_url_text).send().await.or_raise(|| RepoError {
-            message: format!("HEAD request failed for {urn_url_text}"),
-        })?;
+        let response = no_redirect_client
+            .head(urn_url_text)
+            .send()
+            .await
+            .or_raise(|| RepoError {
+                message: format!("HEAD request failed for {urn_url_text}"),
+            })?;
 
         let location = response
             .headers()
@@ -226,7 +224,6 @@ impl DatasetBackend for DabarXmlSrcDataset {
 
         println!("{}", location);
 
-
         let entries = analyze_xml(&doc, &dir, &location)?;
 
         Ok(entries)
@@ -239,8 +236,8 @@ impl DatasetBackend for DabarXmlSrcDataset {
 
 #[cfg(test)]
 mod tests {
-    use crate::CrawlPath;
     use super::*;
+    use crate::CrawlPath;
 
     #[tokio::test]
     async fn test_list() {
@@ -427,7 +424,7 @@ mod tests {
 
         let entries = dataset.list(&client, dir).await.unwrap();
 
-        assert_eq!(entries.len(), 0);
+        assert_eq!(entries.len(), 2);
     }
 
     #[test]
@@ -615,10 +612,10 @@ mod tests {
 
         let location = "https://repozitorij.agr.unizg.hr/object/agr:2814";
 
-        let entries = analyze_xml(&doc, &dir, &location).unwrap();
+        let entries = analyze_xml(&doc, &dir, location).unwrap();
 
         println!("{:?}", entries);
 
-        assert_eq!(entries.len(), 0);
+        assert_eq!(entries.len(), 2);
     }
 }

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -110,7 +110,7 @@ fn analyze_xml(
     let record_identifier = record_identifier.unwrap();
 
     // /oai:record/oai:metadata//mods:mods[mods:physicalDescription/mods:internetMediaType]
-    let file_metas: Vec<_> = root
+    let entries: Vec<_> = root
         .descendants()
         .filter(|n| {
             n.tag_name().name() == "mods"
@@ -121,11 +121,7 @@ fn analyze_xml(
                         && child.tag_name().namespace() == Some(NS_MODS)
                 })
         })
-        .collect();
-
-    let entries = file_metas
-        .iter()
-        .map(|file_meta| make_file_entry(file_meta, &record_identifier, location, dir))
+        .map(|file_meta| make_file_entry(&file_meta, &record_identifier, location, dir))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(entries)
@@ -206,10 +202,9 @@ impl DatasetBackend for DabarXmlSrcDataset {
             .to_str()
             .or_raise(|| RepoError {
                 message: "Location header is not valid UTF-8".to_string(),
-            })?
-            .to_string();
+            })?;
 
-        let entries = analyze_xml(&doc, &dir, &location)?;
+        let entries = analyze_xml(&doc, &dir, location)?;
 
         Ok(entries)
     }

--- a/src/datasets/dataverse.rs
+++ b/src/datasets/dataverse.rs
@@ -212,7 +212,7 @@ pub struct DataverseJsonSrcDataset {
     pub id: String,
     pub base_url: Url,
     pub version: String,
-    pub content: &'static str,
+    pub content: String,
 }
 
 impl DataverseJsonSrcDataset {
@@ -227,7 +227,7 @@ impl DataverseJsonSrcDataset {
             id: id.into(),
             base_url: base_url.clone(),
             version: version.into(),
-            content: Box::leak(content.into_boxed_str()),
+            content,
         }
     }
 }
@@ -235,7 +235,7 @@ impl DataverseJsonSrcDataset {
 #[async_trait]
 impl DatasetBackend for DataverseJsonSrcDataset {
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
-        let json_value: JsonValue = serde_json::from_str(self.content).or_raise(|| RepoError {
+        let json_value: JsonValue = serde_json::from_str(&self.content).or_raise(|| RepoError {
             message: "Failed to parse JSON".to_string(),
         })?;
 

--- a/src/datasets/hal.rs
+++ b/src/datasets/hal.rs
@@ -169,7 +169,7 @@ impl DatasetBackend for HalScience {
 #[derive(Debug)]
 pub struct HalJsonSrcDataset {
     pub id: String,
-    pub content: &'static str,
+    pub content: String,
 }
 
 impl HalJsonSrcDataset {
@@ -177,7 +177,7 @@ impl HalJsonSrcDataset {
     pub fn new(id: impl Into<String>, content: String) -> Self {
         HalJsonSrcDataset {
             id: id.into(),
-            content: Box::leak(content.into_boxed_str()),
+            content,
         }
     }
 }
@@ -219,7 +219,7 @@ impl DatasetBackend for HalJsonSrcDataset {
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
-        let json_value: JsonValue = serde_json::from_str(self.content).or_raise(|| RepoError {
+        let json_value: JsonValue = serde_json::from_str(&self.content).or_raise(|| RepoError {
             message: "Failed to parse JSON".to_string(),
         })?;
 

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -10,6 +10,7 @@ mod osf;
 mod zenodo;
 
 pub use arxiv::Arxiv;
+pub use dabar::DabarXmlSrcDataset;
 pub use dataone::Dataone;
 pub use dataverse::{DataverseDataset, DataverseFile, DataverseJsonSrcDataset};
 pub use dryad::DataDryad;

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -7,6 +7,7 @@ mod hal;
 mod huggingface;
 mod osf;
 mod zenodo;
+mod dabar;
 
 pub use arxiv::Arxiv;
 pub use dataone::Dataone;

--- a/src/datasets/mod.rs
+++ b/src/datasets/mod.rs
@@ -1,4 +1,5 @@
 mod arxiv;
+mod dabar;
 mod dataone;
 mod dataverse;
 mod dryad;
@@ -7,7 +8,6 @@ mod hal;
 mod huggingface;
 mod osf;
 mod zenodo;
-mod dabar;
 
 pub use arxiv::Arxiv;
 pub use dataone::Dataone;

--- a/src/datasets/zenodo.rs
+++ b/src/datasets/zenodo.rs
@@ -176,7 +176,7 @@ impl DatasetBackend for Zenodo {
 #[derive(Debug)]
 pub struct ZenodoJsonSrcDataset {
     pub id: String,
-    pub content: &'static str,
+    pub content: String,
 }
 
 impl ZenodoJsonSrcDataset {
@@ -184,7 +184,7 @@ impl ZenodoJsonSrcDataset {
     pub fn new(id: impl Into<String>, content: String) -> Self {
         ZenodoJsonSrcDataset {
             id: id.into(),
-            content: Box::leak(content.into_boxed_str()),
+            content,
         }
     }
 }
@@ -203,7 +203,7 @@ impl DatasetBackend for ZenodoJsonSrcDataset {
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
-        let json_value: JsonValue = serde_json::from_str(self.content).or_raise(|| RepoError {
+        let json_value: JsonValue = serde_json::from_str(&self.content).or_raise(|| RepoError {
             message: "Failed to parse JSON".to_string(),
         })?;
 


### PR DESCRIPTION
TODOs:

- [x] replace `&'static str` with `String` for Datavrse, Zenodo, and HAL dataset implementations

# URLs

I got some more infos about the URL handling. If we now the repo URL, we can deduce the OAI-PMH call:
- https://repozitorij.meteo.hr/object/meteo:11 ->
https://repozitorij.meteo.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:repozitorij.meteo.hr:meteo_11
- https://data.fulir.irb.hr/en/object/irb:106 -> https://data.fulir.irb.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:data.fulir.irb.hr:irb_106

Note that `:` colon gets transformed in a `_`

Example: https://repozitorij.mef.unizg.hr/object/mef:9391
So the rule seems to be: starting from the repo URL, determine the domain, i.e. `repozitorij.mef.unizg.hr` and the id segment, i.e. `mef:9391`. Then compose as follows https://domain/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:domain:id, e.g. https://repozitorij.mef.unizg.hr/oai/?verb=GetRecord&metadataPrefix=mods&identifier=oai:repozitorij.mef.unizg.hr:mef_9391 


In context of Data Commons, we harvest everything from the same domain https://dabar.srce.hr/oai/ so we do not know the domain of the repo detail page without resolving the URL handle.