### PR TITLE
DatasetBackend API extent to return root_dir instead of root_url to cover non-url cases

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -300,7 +300,27 @@ impl PyDataset {
 
     fn root_url(self_: PyRef<'_, Self>) -> String {
         let repo = self_.0.backend.clone();
-        repo.root_url().as_str().into()
+        let dir_meta = repo.root_dir();
+        dir_meta.root_url().as_str().into()
+    }
+
+    fn root_dir(self_: PyRef<'_, Self>) -> PyResult<Py<PyDirEntry>> {
+        let repo = self_.0.backend.clone();
+        let meta = repo.root_dir();
+
+        Python::attach(|py| {
+            Py::new(
+                py,
+                (
+                    PyDirEntry {
+                        path_crawl_rel: PathBuf::from(meta.path().as_str()),
+                        root_url: meta.root_url().as_str().to_string(),
+                        api_url: meta.api_url().as_str().to_string(),
+                    },
+                    PyEntryBase,
+                ),
+            )
+        })
     }
 
     fn crawl(self_: PyRef<'_, Self>) -> PyResult<PyEntryStream> {

--- a/src/datasets/arxiv.rs
+++ b/src/datasets/arxiv.rs
@@ -28,7 +28,7 @@ impl Arxiv {
 
 #[async_trait]
 impl DatasetBackend for Arxiv {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://arxiv.org/pdf/<id> to get the record pdf
 
         // Safe to unwrap:
@@ -36,7 +36,7 @@ impl DatasetBackend for Arxiv {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://arxiv.org").unwrap();
         url.path_segments_mut().unwrap().extend(["pdf", &self.id]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -145,8 +145,9 @@ impl DabarXmlSrcDataset {
 
 #[async_trait]
 impl DatasetBackend for DabarXmlSrcDataset {
-    fn root_url(&self) -> Url {
-        Url::parse("https://dabar.srce.hr/oai/").unwrap() // static OAI-PMH repo URL
+    fn root_dir(&self) -> DirMeta {
+        let url = Url::parse("https://dabar.srce.hr/oai/").unwrap(); // static OAI-PMH repo URL
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/dataone.rs
+++ b/src/datasets/dataone.rs
@@ -38,7 +38,7 @@ impl Dataone {
 
 #[async_trait]
 impl DatasetBackend for Dataone {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // the dashboard can be at https://data.ess-dive.lbl.gov/view/doi%3A10.15485%2F1971251
         // the xml to describe datasets are all at https://cn.dataone.org/cn/v2/object/
 
@@ -46,7 +46,8 @@ impl DatasetBackend for Dataone {
         // - the base URL is a hard-coded, valid absolute URL
         // - `join` cannot fail for this URL scheme
         let url = Url::from_str("https://cn.dataone.org/cn/v2/object/").unwrap();
-        url.join(&self.id).expect("cannot parse new url")
+        url.join(&self.id).expect("cannot parse new url");
+        DirMeta::new_root(&url)
     }
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
         let resp = client

--- a/src/datasets/dataverse.rs
+++ b/src/datasets/dataverse.rs
@@ -166,8 +166,9 @@ impl DataverseDataset {
 
 #[async_trait]
 impl DatasetBackend for DataverseDataset {
-    fn root_url(&self) -> Url {
-        parse_url(self.base_url.clone(), &self.version, &self.id)
+    fn root_dir(&self) -> DirMeta {
+        let url = parse_url(self.base_url.clone(), &self.version, &self.id);
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
@@ -244,8 +245,9 @@ impl DatasetBackend for DataverseJsonSrcDataset {
         Ok(entries)
     }
 
-    fn root_url(&self) -> Url {
-        parse_url(self.base_url.clone(), &self.version, &self.id)
+    fn root_dir(&self) -> DirMeta {
+        let url = parse_url(self.base_url.clone(), &self.version, &self.id);
+        DirMeta::new_root(&url)
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -274,7 +276,7 @@ impl DataverseFile {
 
 #[async_trait]
 impl DatasetBackend for DataverseFile {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // "https://datavers.example/api/files/:persistentId/versions/:latest-poblished/?persistentId=doi:10.7910/DVN/KBHLOD/DHJ45U"
         // Safe to unwrap:
         // - the base URL is a hard-coded, valid absolute URL
@@ -291,7 +293,7 @@ impl DatasetBackend for DataverseFile {
         }
 
         url.query_pairs_mut().append_pair("persistentId", &self.id);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/dryad.rs
+++ b/src/datasets/dryad.rs
@@ -35,7 +35,7 @@ impl DataDryad {
 #[allow(clippy::too_many_lines)]
 #[async_trait]
 impl DatasetBackend for DataDryad {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://datadryad.org/api/v2/datasets/<id> to start for every dateset entry
 
         // Safe to unwrap:
@@ -43,7 +43,7 @@ impl DatasetBackend for DataDryad {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://datadryad.org/api/v2/datasets").unwrap();
         url.path_segments_mut().unwrap().extend([&self.id]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/github.rs
+++ b/src/datasets/github.rs
@@ -39,7 +39,7 @@ impl GitHub {
 
 #[async_trait]
 impl DatasetBackend for GitHub {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // id for github repo is the commit hash or branch name
 
         // Safe to unwrap:
@@ -57,8 +57,7 @@ impl DatasetBackend for GitHub {
         }
 
         url.query_pairs_mut().append_pair("ref", &self.reference);
-
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/hal.rs
+++ b/src/datasets/hal.rs
@@ -95,7 +95,7 @@ impl HalScience {
 
 #[async_trait]
 impl DatasetBackend for HalScience {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // HAL Search API endpoint
         // can get files of a record by following search api call, e.g. for 'cel-01830944'
         // curl "https://api.archives-ouvertes.fr/search/?q=halId_s:cel-01830943&wt=json&fl=halId_s,fileMain_s,files_s,fileType_s"
@@ -125,8 +125,7 @@ impl DatasetBackend for HalScience {
             .append_pair("q", &format!("halId_s:{}", self.id))
             .append_pair("wt", "json")
             .append_pair("fl", "halId_s,fileMain_s,files_s,fileType_s,producedDate_tdate,modifiedDate_tdate,version_i"); // https://api.archives-ouvertes.fr/docs/search/?schema=fields#fields
-
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
@@ -184,7 +183,7 @@ impl HalJsonSrcDataset {
 
 #[async_trait]
 impl DatasetBackend for HalJsonSrcDataset {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // HAL Search API endpoint
         // can get files of a record by following search api call, e.g. for 'cel-01830944'
         // curl "https://api.archives-ouvertes.fr/search/?q=halId_s:cel-01830943&wt=json&fl=halId_s,fileMain_s,files_s,fileType_s"
@@ -214,8 +213,7 @@ impl DatasetBackend for HalJsonSrcDataset {
             .append_pair("q", &format!("halId_s:{}", self.id))
             .append_pair("wt", "json")
             .append_pair("fl", "halId_s,fileMain_s,files_s,fileType_s,producedDate_tdate,modifiedDate_tdate,version_i");
-
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/huggingface.rs
+++ b/src/datasets/huggingface.rs
@@ -50,15 +50,14 @@ impl HuggingFace {
 
 #[async_trait]
 impl DatasetBackend for HuggingFace {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://huggingface.co/api/datasets/{owner}/{repo}/tree/{revision}/{path}
         let mut url = Url::parse("https://huggingface.co/api/datasets").unwrap();
         // safe to unwrap, we know the url.
         url.path_segments_mut()
             .unwrap()
             .extend([&self.owner, &self.repo, "tree", &self.revision]);
-
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/materialsclound.rs
+++ b/src/datasets/materialsclound.rs
@@ -124,7 +124,7 @@ impl MaterialsCloud {
 #[allow(clippy::too_many_lines)]
 #[async_trait]
 impl DatasetBackend for MaterialsCloud {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://archive.materialscloud.org/api/record/<id> to start for every dateset entry
 
         // Safe to unwrap:
@@ -132,7 +132,7 @@ impl DatasetBackend for MaterialsCloud {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://archive.materialscloud.org/api/records").unwrap();
         url.path_segments_mut().unwrap().extend([&self.id, "files"]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/osf.rs
+++ b/src/datasets/osf.rs
@@ -30,7 +30,7 @@ impl OSF {
 
 #[async_trait]
 impl DatasetBackend for OSF {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://api.osf.io/v2/nodes/<id>/files to start for every dateset entry
 
         // Safe to unwrap:
@@ -38,7 +38,7 @@ impl DatasetBackend for OSF {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://api.osf.io/v2/nodes/").unwrap();
         url.path_segments_mut().unwrap().extend([&self.id, "files"]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/datasets/zenodo.rs
+++ b/src/datasets/zenodo.rs
@@ -124,7 +124,7 @@ impl Zenodo {
 #[allow(clippy::too_many_lines)]
 #[async_trait]
 impl DatasetBackend for Zenodo {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://zenodo.org/api/<id> to start for every dateset entry
 
         // Safe to unwrap:
@@ -132,7 +132,7 @@ impl DatasetBackend for Zenodo {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://zenodo.org/api/records").unwrap();
         url.path_segments_mut().unwrap().extend([&self.id, "files"]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
@@ -191,7 +191,7 @@ impl ZenodoJsonSrcDataset {
 
 #[async_trait]
 impl DatasetBackend for ZenodoJsonSrcDataset {
-    fn root_url(&self) -> Url {
+    fn root_dir(&self) -> DirMeta {
         // https://zenodo.org/api/<id> to start for every dateset entry
 
         // Safe to unwrap:
@@ -199,7 +199,7 @@ impl DatasetBackend for ZenodoJsonSrcDataset {
         // - `path_segments_mut` cannot fail for this URL scheme
         let mut url = Url::from_str("https://zenodo.org/api/records").unwrap();
         url.path_segments_mut().unwrap().extend([&self.id, "files"]);
-        url
+        DirMeta::new_root(&url)
     }
 
     async fn list(&self, _client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -425,7 +425,7 @@ impl std::error::Error for RepoError {}
 #[async_trait]
 pub trait DatasetBackend: Send + Sync + Any {
     async fn list(&self, client: &Client, dir: DirMeta) -> Result<Vec<Entry>, Exn<RepoError>>;
-    fn root_url(&self) -> Url;
+    fn root_dir(&self) -> DirMeta;
     fn as_any(&self) -> &dyn Any;
 }
 
@@ -443,6 +443,6 @@ impl Dataset {
     }
     #[must_use]
     pub fn root_dir(&self) -> DirMeta {
-        DirMeta::new_root(&self.backend.root_url())
+        self.backend.root_dir()
     }
 }


### PR DESCRIPTION
- The reason to make this change is for extending the concept to making it possible to wording it properly for dataset source where the root is not a url.
- ~~follow the design described in #93~~