### PR TITLE
fix (Python stubs): add missing stub for ZipEntry

### DIFF
--- a/python/datahugger/__init__.py
+++ b/python/datahugger/__init__.py
@@ -3,6 +3,8 @@ from .datahugger import (
     DOIResolver,
     DirEntry,
     FileEntry,
+    FileInZipEntry,
+    ZipEntry,
     Dataset,
     DataverseJsonSrcDataset,
     ZenodoJsonSrcDataset,
@@ -19,5 +21,7 @@ __all__ = (
     "DabarXmlSrcDataset",
     "DirEntry",
     "FileEntry",
+    "FileInZipEntry",
+    "ZipEntry",
     "Dataset",
 )

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -34,7 +34,7 @@ class FileEntry(Entry):
     last_modification_date: str | None
 
 @dataclass
-class FileInZipEntry:
+class FileInZipEntry(Entry):
     filename: str | None
     file_identifier: str | None
     path_crawl_rel: pathlib.Path

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -33,6 +33,14 @@ class FileEntry(Entry):
     creation_date: str | None
     last_modification_date: str | None
 
+
+@dataclass
+class FileInZipEntry:
+    filename: str | None
+    file_identifier: str | None
+    path_crawl_rel: pathlib.Path
+    mimetype: str | None
+
 @dataclass
 class ZipEntry(Entry):
     download_url: str
@@ -41,6 +49,7 @@ class ZipEntry(Entry):
     version: str | None
     creation_date: str | None
     last_modification_date: str | None
+    files: list[FileInZipEntry]
 
 class DataverseJsonSrcDataset(Dataset):
     """

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -33,6 +33,15 @@ class FileEntry(Entry):
     creation_date: str | None
     last_modification_date: str | None
 
+@dataclass
+class ZipEntry(Entry):
+    download_url: str
+    size: int | None
+    checksum: list[tuple[str, str]]
+    version: str | None
+    creation_date: str | None
+    last_modification_date: str | None
+
 class DataverseJsonSrcDataset(Dataset):
     """
     A Dataverse dataset backend that uses pre-fetched JSON content.
@@ -112,7 +121,7 @@ class Dataset(object):
         """blocking call, using rust's async runtime, return number of files it downloads"""
     def crawl_file(self) -> SyncAsyncIterator[FileEntry]:
         """returns a stream that can be either sync or async iterator over `FileEntry`"""
-    def crawl(self) -> SyncAsyncIterator[FileEntry | DirEntry]:
+    def crawl(self) -> SyncAsyncIterator[FileEntry | DirEntry | ZipEntry]:
         """returns a stream that can be either sync or async iterator over `FileEntry | DirEntry`"""
     def root_url(self) -> str: ...
 

--- a/python/datahugger/datahugger.pyi
+++ b/python/datahugger/datahugger.pyi
@@ -33,7 +33,6 @@ class FileEntry(Entry):
     creation_date: str | None
     last_modification_date: str | None
 
-
 @dataclass
 class FileInZipEntry:
     filename: str | None


### PR DESCRIPTION
This PR adds the missing definition for `ZipEntry` in Python stubs.