### PR TITLE
refactor(dabar): read file links directly from MODS XML

### DIFF
--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -60,6 +60,7 @@ fn make_file_entry(
         .find(|n| {
             n.tag_name().name() == "url"
                 && n.tag_name().namespace() == Some(NS_MODS)
+                && n.has_attribute("access")
                 && n.parent().is_some_and(|p| {
                     p.tag_name().name() == "location" && p.tag_name().namespace() == Some(NS_MODS)
                 })

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::upper_case_acronyms)]
 
 use async_trait::async_trait;
-use exn::{Exn, ResultExt};
+use exn::{Exn, OptionExt, ResultExt};
 use reqwest_middleware::ClientWithMiddleware;
 use url::Url;
 
@@ -10,7 +10,6 @@ use crate::{
     DatasetBackend, DirMeta, Entry,
 };
 use mime::Mime;
-use reqwest::Client;
 use std::any::Any;
 
 // Namespace constants mirroring Python's NS dict
@@ -19,7 +18,6 @@ const NS_MODS: &str = "http://www.loc.gov/mods/v3";
 fn make_file_entry(
     file_meta: &roxmltree::Node,
     record_identifier: &roxmltree::Node,
-    location: &str,
     dir: &DirMeta,
 ) -> Result<Entry, Exn<RepoError>> {
     let file_identifier = file_meta.attribute("ID").ok_or_else(|| {
@@ -57,10 +55,16 @@ fn make_file_entry(
         })
     })?;
 
-    let download_url: Url = format!("{location}/{file_identifier}/download")
+    let download_url: Url = file_meta
+        .descendants()
+        .find(|n| n.tag_name().name() == "url" && n.tag_name().namespace() == Some(NS_MODS))
+        .and_then(|n| n.text())
+        .ok_or_raise(|| RepoError {
+            message: format!("Could not build download URL for identifier={record_id_text}"),
+        })?
         .parse::<Url>()
         .or_raise(|| RepoError {
-            message: format!("Could not build download URL for identifier={record_id_text}"),
+            message: format!("Could not parse download URL for identifier={record_id_text}"),
         })?;
 
     let endpoint = Endpoint {
@@ -84,11 +88,7 @@ fn make_file_entry(
     )))
 }
 
-fn analyze_xml(
-    doc: &roxmltree::Document,
-    dir: &DirMeta,
-    location: &str,
-) -> Result<Vec<Entry>, Exn<RepoError>> {
+fn analyze_xml(doc: &roxmltree::Document, dir: &DirMeta) -> Result<Vec<Entry>, Exn<RepoError>> {
     let root = doc.root_element();
 
     // /oai:record/oai:metadata//mods:identifier[@type="local"]
@@ -122,7 +122,7 @@ fn analyze_xml(
                         && child.tag_name().namespace() == Some(NS_MODS)
                 })
         })
-        .map(|file_meta| make_file_entry(&file_meta, &record_identifier, location, dir))
+        .map(|file_meta| make_file_entry(&file_meta, &record_identifier, dir))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(entries)
@@ -160,57 +160,7 @@ impl DatasetBackend for DabarXmlSrcDataset {
             message: "Failed to parse XML".to_string(),
         })?;
 
-        // /oai:record/oai:metadata//mods:location/mods:url[@displayLabel="URN:NBN"]
-        let urn_url_node = doc
-            .descendants()
-            .find(|n| {
-                n.tag_name().name() == "url"
-                    && n.tag_name().namespace() == Some(NS_MODS)
-                    && n.attribute("displayLabel") == Some("URN:NBN")
-            })
-            .ok_or_else(|| {
-                Exn::new(RepoError {
-                    message: "No location url (URN:NBN) found in record".to_string(),
-                })
-            })?;
-
-        let urn_url_text = urn_url_node.text().ok_or_else(|| {
-            Exn::new(RepoError {
-                message: "URN:NBN url node has no text".to_string(),
-            })
-        })?;
-
-        // Build a client to resolve the URL handle to figure out the domain to build the download links.
-        // TODO: Once DABAR MODS contains the domains, this logic can be removed.
-        let no_redirect_client = Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .or_raise(|| RepoError {
-                message: "Failed to build HTTP client".to_string(),
-            })?;
-
-        let response = no_redirect_client
-            .head(urn_url_text)
-            .send()
-            .await
-            .or_raise(|| RepoError {
-                message: format!("HEAD request failed for {urn_url_text}"),
-            })?;
-
-        let location = response
-            .headers()
-            .get("Location")
-            .ok_or_else(|| {
-                Exn::new(RepoError {
-                    message: "No location header in response".to_string(),
-                })
-            })?
-            .to_str()
-            .or_raise(|| RepoError {
-                message: "Location header is not valid UTF-8".to_string(),
-            })?;
-
-        let entries = analyze_xml(&doc, &dir, location)?;
+        let entries = analyze_xml(&doc, &dir)?;
 
         Ok(entries)
     }
@@ -222,372 +172,188 @@ impl DatasetBackend for DabarXmlSrcDataset {
 
 #[cfg(test)]
 mod tests {
-    use reqwest_middleware::ClientBuilder;
-
     use super::*;
     use crate::CrawlPath;
-
-    #[tokio::test]
-    async fn test_list() {
-        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
-<record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <header>
-    <identifier>oai:dabar.srce.hr:agr_2814</identifier>
-    <datestamp>2025-10-27</datestamp>
-  </header>
-  <metadata>
-    <modsCollection xmlns="http://www.loc.gov/mods/v3" xmlns:dabar="http://dabar.srce.hr/standards/schema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:etd="http://www.ndltd.org/standards/metadata/etdms/1.0" xmlns:datacite="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-8.xsd http://dabar.srce.hr/standards/schema/1.0 https://dabar.srce.hr/standards/schema/1.0/dabar.xsd">
-      <mods ID="master" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <identifier type="local">agr:2814</identifier>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Lana</namePart>
-          <namePart type="family">Filipović</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Vilim</namePart>
-          <namePart type="family">Filipović</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Zoran</namePart>
-          <namePart type="family">Kovač</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Vedran</namePart>
-          <namePart type="family">Krevh</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Jasmina</namePart>
-          <namePart type="family">Defterdarović</namePart>
-        </name>
-        <titleInfo lang="eng" usage="primary">
-          <title>SUPREHILL Critical Zone Observatory dataset - funded by Croatian Science Foundation (HRZZ)</title>
-        </titleInfo>
-        <language>
-          <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
-        </language>
-        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="hrv" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">eksperimentalni podaci</genre>
-        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="eng" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">experimental data</genre>
-        <genre authority="coar" authorityURI="https://vocabularies.coar-repositories.org/resource_types/" valueURI="http://purl.org/coar/resource_type/63NG-B465">experimental data</genre>
-        <abstract lang="eng" type="primary">Data collected at the SUPREHILL Critical Zone Observatory (CZO), funded by Croatian Science Foundation (HRZZ)</abstract>
-        <subject lang="eng" usage="primary">
-          <topic>SUPREHILL</topic>
-          <topic>critical zone observatory</topic>
-          <topic>vadose zone</topic>
-          <topic>hillslope</topic>
-          <topic>vineyard</topic>
-        </subject>
-        <subject authority="nvzz.hr" ID="4#4.01#4.01.03">
-          <topic lang="hrv">Biotehničke znanosti</topic>
-          <topic lang="eng">Biotechnical Sciences</topic>
-          <topic lang="hrv">Poljoprivreda</topic>
-          <topic lang="eng">Agriculture</topic>
-          <topic lang="hrv">ekologija i zaštita okoliša</topic>
-          <topic lang="eng">Ecology and Environmental Protection</topic>
-        </subject>
-        <relatedItem type="constituent" displayLabel="project">
-          <identifier type="local">4284</identifier>
-          <identifier>UIP-2019-04-5409</identifier>
-          <titleInfo lang="hrv">
-            <title>Podpovršinski preferencijalni transportni procesi u poljoprivrednim padinskim tlima</title>
-          </titleInfo>
-          <titleInfo lang="eng">
-            <title>SUbsurface PREferential transport processes in agricultural HILLslope soils</title>
-          </titleInfo>
-          <name type="personal">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pdr">project director</roleTerm>
-              <roleTerm lang="hrv" type="text">Voditelj projekta</roleTerm>
-            </role>
-            <namePart>Vilim Filipović</namePart>
-          </name>
-          <name type="corporate" authority="iso3166">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/jug">jurisdiction governed</roleTerm>
-            </role>
-            <namePart>Hrvatska</namePart>
-          </name>
-          <name type="corporate">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
-            </role>
-            <namePart displayLabel="funder name">Hrvatska zaklada za znanost</namePart>
-          </name>
-          <note type="funding" displayLabel="funder programme">Installation Research Projects</note>
-          <titleInfo type="abbreviated">
-            <title>SUPREHILL</title>
-          </titleInfo>
-        </relatedItem>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-        <physicalDescription/>
-        <physicalDescription/>
-        <physicalDescription/>
-        <subject>
-          <geographic authority="iso3166">HR</geographic>
-          <geographic>Jazbina</geographic>
-        </subject>
-        <abstract type="methods" lang="eng">Data collected at the SUPREHILL CZO (https://sites.google.com/view/suprehill) is separated into three main categories.: 1) data collected by field measurements 2) data collected by individual field and laboratory experiments 3) data collected by laboratory analyses</abstract>
-        <name type="corporate">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pbl">publisher</roleTerm>
-            <roleTerm type="text" lang="hrv">izdavač</roleTerm>
-          </role>
-          <namePart lang="hrv">Agronomski fakultet</namePart>
-          <namePart lang="eng">Faculty of Agriculture</namePart>
-        </name>
-        <location>
-          <url access="object in context" usage="primary" displayLabel="URN:NBN">https://urn.nsk.hr/urn:nbn:hr:204:468943</url>
-        </location>
-        <identifier type="urn">urn:nbn:hr:204:468943</identifier>
-        <recordInfo>
-          <recordIdentifier>agr:2814/mods:2023-02-22T12:55:29+01:00</recordIdentifier>
-          <recordCreationDate encoding="iso8601">2023-02-22T12:55:29+01:00</recordCreationDate>
-          <recordContentSource authority="local">agr</recordContentSource>
-          <recordContentSource>Repozitorij Agronomskog fakulteta u Zagrebu</recordContentSource>
-          <recordChangeDate encoding="iso8601">2024-02-27T13:54:10+01:00</recordChangeDate>
-        </recordInfo>
-        <name type="personal">
-          <namePart type="given">Lana</namePart>
-          <namePart type="family">Filipović</namePart>
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dtc">data contributor</roleTerm>
-            <roleTerm type="text" lang="hrv">Djelatnik</roleTerm>
-          </role>
-        </name>
-        <name type="personal">
-          <namePart type="given">Valentina</namePart>
-          <namePart type="family">Bezek</namePart>
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/edt">editor</roleTerm>
-            <roleTerm type="text">data editor</roleTerm>
-          </role>
-        </name>
-        <genre authority="dabar" type="object type">dataset</genre>
-        <extension>
-          <dabar:kontaktZaCjelovitiTekst>lfilipovic@agr.hr</dabar:kontaktZaCjelovitiTekst>
-        </extension>
-      </mods>
-      <mods ID="FILE0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <physicalDescription>
-          <internetMediaType>application/zip</internetMediaType>
-        </physicalDescription>
-        <abstract displayLabel="data description" lang="eng">SUPREHILL database</abstract>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-        <identifier type="file">primary file</identifier>
-      </mods>
-      <mods ID="DOC0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <physicalDescription>
-          <internetMediaType>application/vnd.openxmlformats-officedocument.wordprocessingml.document</internetMediaType>
-        </physicalDescription>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-      </mods>
-    </modsCollection>
-  </metadata>
-</record>"#;
-
-        let dataset = DabarXmlSrcDataset::new("test-id", xml.to_string());
-        let client = ClientBuilder::new(Client::new()).build();
-        let dir = DirMeta::new(
-            CrawlPath::root(),
-            Url::parse("https://example.com/api").unwrap(),
-            Url::parse("https://example.com").unwrap(),
-        );
-
-        let entries = dataset.list(&client, dir).await.unwrap();
-
-        assert_eq!(entries.len(), 2);
-    }
 
     #[test]
     fn test_analyze_xml() {
         let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <record xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <header>
-    <identifier>oai:dabar.srce.hr:agr_2814</identifier>
-    <datestamp>2025-10-27</datestamp>
-  </header>
-  <metadata>
-    <modsCollection xmlns="http://www.loc.gov/mods/v3" xmlns:dabar="http://dabar.srce.hr/standards/schema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:etd="http://www.ndltd.org/standards/metadata/etdms/1.0" xmlns:datacite="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-8.xsd http://dabar.srce.hr/standards/schema/1.0 https://dabar.srce.hr/standards/schema/1.0/dabar.xsd">
-      <mods ID="master" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <identifier type="local">agr:2814</identifier>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Lana</namePart>
-          <namePart type="family">Filipović</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Vilim</namePart>
-          <namePart type="family">Filipović</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Zoran</namePart>
-          <namePart type="family">Kovač</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Vedran</namePart>
-          <namePart type="family">Krevh</namePart>
-        </name>
-        <name type="personal">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
-          </role>
-          <namePart type="given">Jasmina</namePart>
-          <namePart type="family">Defterdarović</namePart>
-        </name>
-        <titleInfo lang="eng" usage="primary">
-          <title>SUPREHILL Critical Zone Observatory dataset - funded by Croatian Science Foundation (HRZZ)</title>
-        </titleInfo>
-        <language>
-          <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
-        </language>
-        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="hrv" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">eksperimentalni podaci</genre>
-        <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="eng" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">experimental data</genre>
-        <genre authority="coar" authorityURI="https://vocabularies.coar-repositories.org/resource_types/" valueURI="http://purl.org/coar/resource_type/63NG-B465">experimental data</genre>
-        <abstract lang="eng" type="primary">Data collected at the SUPREHILL Critical Zone Observatory (CZO), funded by Croatian Science Foundation (HRZZ)</abstract>
-        <subject lang="eng" usage="primary">
-          <topic>SUPREHILL</topic>
-          <topic>critical zone observatory</topic>
-          <topic>vadose zone</topic>
-          <topic>hillslope</topic>
-          <topic>vineyard</topic>
-        </subject>
-        <subject authority="nvzz.hr" ID="4#4.01#4.01.03">
-          <topic lang="hrv">Biotehničke znanosti</topic>
-          <topic lang="eng">Biotechnical Sciences</topic>
-          <topic lang="hrv">Poljoprivreda</topic>
-          <topic lang="eng">Agriculture</topic>
-          <topic lang="hrv">ekologija i zaštita okoliša</topic>
-          <topic lang="eng">Ecology and Environmental Protection</topic>
-        </subject>
-        <relatedItem type="constituent" displayLabel="project">
-          <identifier type="local">4284</identifier>
-          <identifier>UIP-2019-04-5409</identifier>
-          <titleInfo lang="hrv">
-            <title>Podpovršinski preferencijalni transportni procesi u poljoprivrednim padinskim tlima</title>
-          </titleInfo>
-          <titleInfo lang="eng">
-            <title>SUbsurface PREferential transport processes in agricultural HILLslope soils</title>
-          </titleInfo>
-          <name type="personal">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pdr">project director</roleTerm>
-              <roleTerm lang="hrv" type="text">Voditelj projekta</roleTerm>
-            </role>
-            <namePart>Vilim Filipović</namePart>
-          </name>
-          <name type="corporate" authority="iso3166">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/jug">jurisdiction governed</roleTerm>
-            </role>
-            <namePart>Hrvatska</namePart>
-          </name>
-          <name type="corporate">
-            <role>
-              <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
-            </role>
-            <namePart displayLabel="funder name">Hrvatska zaklada za znanost</namePart>
-          </name>
-          <note type="funding" displayLabel="funder programme">Installation Research Projects</note>
-          <titleInfo type="abbreviated">
-            <title>SUPREHILL</title>
-          </titleInfo>
-        </relatedItem>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-        <physicalDescription/>
-        <physicalDescription/>
-        <physicalDescription/>
-        <subject>
-          <geographic authority="iso3166">HR</geographic>
-          <geographic>Jazbina</geographic>
-        </subject>
-        <abstract type="methods" lang="eng">Data collected at the SUPREHILL CZO (https://sites.google.com/view/suprehill) is separated into three main categories.: 1) data collected by field measurements 2) data collected by individual field and laboratory experiments 3) data collected by laboratory analyses</abstract>
-        <name type="corporate">
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pbl">publisher</roleTerm>
-            <roleTerm type="text" lang="hrv">izdavač</roleTerm>
-          </role>
-          <namePart lang="hrv">Agronomski fakultet</namePart>
-          <namePart lang="eng">Faculty of Agriculture</namePart>
-        </name>
-        <location>
-          <url access="object in context" usage="primary" displayLabel="URN:NBN">https://urn.nsk.hr/urn:nbn:hr:204:468943</url>
-        </location>
-        <identifier type="urn">urn:nbn:hr:204:468943</identifier>
-        <recordInfo>
-          <recordIdentifier>agr:2814/mods:2023-02-22T12:55:29+01:00</recordIdentifier>
-          <recordCreationDate encoding="iso8601">2023-02-22T12:55:29+01:00</recordCreationDate>
-          <recordContentSource authority="local">agr</recordContentSource>
-          <recordContentSource>Repozitorij Agronomskog fakulteta u Zagrebu</recordContentSource>
-          <recordChangeDate encoding="iso8601">2024-02-27T13:54:10+01:00</recordChangeDate>
-        </recordInfo>
-        <name type="personal">
-          <namePart type="given">Lana</namePart>
-          <namePart type="family">Filipović</namePart>
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dtc">data contributor</roleTerm>
-            <roleTerm type="text" lang="hrv">Djelatnik</roleTerm>
-          </role>
-        </name>
-        <name type="personal">
-          <namePart type="given">Valentina</namePart>
-          <namePart type="family">Bezek</namePart>
-          <role>
-            <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/edt">editor</roleTerm>
-            <roleTerm type="text">data editor</roleTerm>
-          </role>
-        </name>
-        <genre authority="dabar" type="object type">dataset</genre>
-        <extension>
-          <dabar:kontaktZaCjelovitiTekst>lfilipovic@agr.hr</dabar:kontaktZaCjelovitiTekst>
-        </extension>
-      </mods>
-      <mods ID="FILE0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <physicalDescription>
-          <internetMediaType>application/zip</internetMediaType>
-        </physicalDescription>
-        <abstract displayLabel="data description" lang="eng">SUPREHILL database</abstract>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-        <identifier type="file">primary file</identifier>
-      </mods>
-      <mods ID="DOC0" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
-        <physicalDescription>
-          <internetMediaType>application/vnd.openxmlformats-officedocument.wordprocessingml.document</internetMediaType>
-        </physicalDescription>
-        <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
-        <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
-      </mods>
-    </modsCollection>
-  </metadata>
+        <identifier>oai:data.fulir.irb.hr:agr_2814</identifier>
+        <datestamp>2024-10-24</datestamp>
+      </header>
+      <metadata>
+        <modsCollection xmlns="http://www.loc.gov/mods/v3" xmlns:dabar="http://dabar.srce.hr/standards/schema/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:etd="http://www.ndltd.org/standards/metadata/etdms/1.0" xmlns:datacite="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-8.xsd http://dabar.srce.hr/standards/schema/1.0 https://dabar.srce.hr/standards/schema/1.0/dabar.xsd">
+  <mods ID="master" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-6.xsd">
+    <identifier type="local">agr:2814</identifier>
+    <name type="personal">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+      </role>
+      <namePart type="given">Lana</namePart>
+      <namePart type="family">Filipović</namePart>
+    </name>
+    <name type="personal">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+      </role>
+      <namePart type="given">Vilim</namePart>
+      <namePart type="family">Filipović</namePart>
+    </name>
+    <name type="personal">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+      </role>
+      <namePart type="given">Zoran</namePart>
+      <namePart type="family">Kovač</namePart>
+    </name>
+    <name type="personal">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+      </role>
+      <namePart type="given">Vedran</namePart>
+      <namePart type="family">Krevh</namePart>
+    </name>
+    <name type="personal">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/aut">author</roleTerm>
+      </role>
+      <namePart type="given">Jasmina</namePart>
+      <namePart type="family">Defterdarović</namePart>
+    </name>
+    <titleInfo lang="eng" usage="primary">
+      <title>SUPREHILL Critical Zone Observatory dataset - funded by Croatian Science Foundation (HRZZ)</title>
+    </titleInfo>
+    <language>
+      <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+    </language>
+    <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="hrv" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">eksperimentalni podaci</genre>
+    <genre authority="HRZVO-KR-HRZVO-KR-Vrsta_podataka" lang="eng" valueURI="HRZVO-KR-HRZVO-KR-Vrsta_podataka:3">experimental data</genre>
+    <genre authority="coar" authorityURI="https://vocabularies.coar-repositories.org/resource_types/" valueURI="http://purl.org/coar/resource_type/63NG-B465">experimental data</genre>
+    <abstract lang="eng" type="primary">Data collected at the SUPREHILL Critical Zone Observatory (CZO), funded by Croatian Science Foundation (HRZZ)</abstract>
+    <subject lang="eng" usage="primary">
+      <topic>SUPREHILL</topic>
+      <topic>critical zone observatory</topic>
+      <topic>vadose zone</topic>
+      <topic>hillslope</topic>
+      <topic>vineyard</topic>
+    </subject>
+    <subject authority="nvzz.hr" ID="4#4.01#4.01.03">
+      <topic lang="hrv">Biotehničke znanosti</topic>
+      <topic lang="eng">Biotechnical Sciences</topic>
+      <topic lang="hrv">Poljoprivreda</topic>
+      <topic lang="eng">Agriculture</topic>
+      <topic lang="hrv">ekologija i zaštita okoliša</topic>
+      <topic lang="eng">Ecology and Environmental Protection</topic>
+    </subject>
+    <relatedItem type="constituent" displayLabel="project">
+      <identifier type="local">4284</identifier>
+      <identifier>UIP-2019-04-5409</identifier>
+      <titleInfo lang="hrv">
+        <title>Podpovršinski preferencijalni transportni procesi u poljoprivrednim padinskim tlima</title>
+      </titleInfo>
+      <titleInfo lang="eng">
+        <title>SUbsurface PREferential transport processes in agricultural HILLslope soils</title>
+      </titleInfo>
+      <name type="personal">
+        <role>
+          <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pdr">project director</roleTerm>
+          <roleTerm lang="hrv" type="text">Voditelj projekta</roleTerm>
+        </role>
+        <namePart>Vilim Filipović</namePart>
+      </name>
+      <name type="corporate" authority="iso3166">
+        <role>
+          <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/jug">jurisdiction governed</roleTerm>
+        </role>
+        <namePart>Hrvatska</namePart>
+      </name>
+      <name type="corporate">
+        <role>
+          <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/fnd">funder</roleTerm>
+        </role>
+        <namePart displayLabel="funder name">Hrvatska zaklada za znanost</namePart>
+      </name>
+      <note type="funding" displayLabel="funder programme">Installation Research Projects</note>
+      <titleInfo type="abbreviated">
+        <title>SUPREHILL</title>
+      </titleInfo>
+    </relatedItem>
+    <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+    <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+    <physicalDescription/>
+    <physicalDescription/>
+    <physicalDescription/>
+    <subject>
+      <geographic authority="iso3166">HR</geographic>
+      <geographic>Jazbina</geographic>
+    </subject>
+    <abstract type="methods" lang="eng">Data collected at the SUPREHILL CZO (https://sites.google.com/view/suprehill) is separated into three main categories.: 1) data collected by field measurements 2) data collected by individual field and laboratory experiments 3) data collected by laboratory analyses</abstract>
+    <name type="corporate">
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/pbl">publisher</roleTerm>
+        <roleTerm type="text" lang="hrv">izdavač</roleTerm>
+      </role>
+      <namePart lang="hrv">Agronomski fakultet</namePart>
+      <namePart lang="eng">Faculty of Agriculture</namePart>
+    </name>
+    <location>
+      <url access="object in context" usage="primary" displayLabel="URN:NBN">https://urn.nsk.hr/urn:nbn:hr:204:468943</url>
+    </location>
+    <identifier type="urn">urn:nbn:hr:204:468943</identifier>
+    <recordInfo>
+      <recordIdentifier>agr:2814/mods:2023-02-22T12:55:29+01:00</recordIdentifier>
+      <recordCreationDate encoding="iso8601">2023-02-22T12:55:29+01:00</recordCreationDate>
+      <recordContentSource authority="local">agr</recordContentSource>
+      <recordContentSource>Repozitorij Agronomskog fakulteta u Zagrebu</recordContentSource>
+      <recordChangeDate encoding="iso8601">2024-02-27T13:54:10+01:00</recordChangeDate>
+    </recordInfo>
+    <name type="personal">
+      <namePart type="given">Lana</namePart>
+      <namePart type="family">Filipović</namePart>
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/dtc">data contributor</roleTerm>
+        <roleTerm type="text" lang="hrv">Djelatnik</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart type="given">Valentina</namePart>
+      <namePart type="family">Bezek</namePart>
+      <role>
+        <roleTerm type="text" authority="loc" authorityURI="https://id.loc.gov/vocabulary/relators" valueURI="http://id.loc.gov/vocabulary/relators/edt">editor</roleTerm>
+        <roleTerm type="text">data editor</roleTerm>
+      </role>
+    </name>
+    <genre authority="dabar" type="object type">dataset</genre>
+    <extension>
+      <dabar:kontaktZaCjelovitiTekst>lfilipovic@agr.hr</dabar:kontaktZaCjelovitiTekst>
+    </extension>
+  </mods>
+  <mods ID="FILE0">
+    <location>
+      <url access="primary display">https://repozitorij.agr.unizg.hr/object/agr:2814/FILE0</url>
+    </location>
+    <physicalDescription>
+      <internetMediaType>application/zip</internetMediaType>
+    </physicalDescription>
+    <abstract displayLabel="data description" lang="eng">SUPREHILL database</abstract>
+    <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+    <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+    <identifier type="file">primary file</identifier>
+  </mods>
+  <mods ID="DOC0">
+    <location>
+      <url access="raw object">https://repozitorij.agr.unizg.hr/object/agr:2814/DOC0</url>
+    </location>
+    <physicalDescription>
+      <internetMediaType>application/vnd.openxmlformats-officedocument.wordprocessingml.document</internetMediaType>
+    </physicalDescription>
+    <accessCondition type="restriction on access" authority="HRZVO-KR-PravaPristupa">openAccess</accessCondition>
+    <accessCondition type="use and reproduction">http://rightsstatements.org/vocab/InC/1.0/</accessCondition>
+  </mods>
+</modsCollection>
+      </metadata>
 </record>
 "#;
 
@@ -598,9 +364,7 @@ mod tests {
             Url::parse("https://example.com").unwrap(),
         );
 
-        let location = "https://repozitorij.agr.unizg.hr/object/agr:2814";
-
-        let entries = analyze_xml(&doc, &dir, location).unwrap();
+        let entries = analyze_xml(&doc, &dir).unwrap();
 
         println!("{:?}", entries);
 

--- a/src/datasets/dabar.rs
+++ b/src/datasets/dabar.rs
@@ -57,7 +57,13 @@ fn make_file_entry(
 
     let download_url: Url = file_meta
         .descendants()
-        .find(|n| n.tag_name().name() == "url" && n.tag_name().namespace() == Some(NS_MODS))
+        .find(|n| {
+            n.tag_name().name() == "url"
+                && n.tag_name().namespace() == Some(NS_MODS)
+                && n.parent().is_some_and(|p| {
+                    p.tag_name().name() == "location" && p.tag_name().namespace() == Some(NS_MODS)
+                })
+        })
         .and_then(|n| n.text())
         .ok_or_raise(|| RepoError {
             message: format!("Could not build download URL for identifier={record_id_text}"),
@@ -365,8 +371,6 @@ mod tests {
         );
 
         let entries = analyze_xml(&doc, &dir).unwrap();
-
-        println!("{:?}", entries);
 
         assert_eq!(entries.len(), 2);
     }


### PR DESCRIPTION
DABAR changed their XML MODS format to directly include file links. Now it is not necessary anymore to resolve the handle to build the links to the files located at their respective repos as before. 

A file description now contains:
```xml
<location>
      <url access="raw object">https://repozitorij.agr.unizg.hr/object/agr:2814/DOC0</url>
</location>
```

see https://github.com/EOSC-Data-Commons/metadata-warehouse/issues/156